### PR TITLE
feat(eth-staking): add staking modal layout

### DIFF
--- a/packages/suite/src/components/suite/FormFractionButtons.tsx
+++ b/packages/suite/src/components/suite/FormFractionButtons.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { Translation } from 'src/components/suite';
+import { Button } from '@trezor/components';
+
+const Flex = styled.div`
+    display: flex;
+    gap: 4px;
+`;
+
+const SmallButton = styled(Button).attrs(props => ({
+    ...props,
+    variant: 'tertiary',
+    type: 'button',
+    size: 'small',
+}))``;
+
+interface FormFractionButtonsProps {
+    setRatioAmount: (divisor: number) => void;
+    setMax: () => void;
+    isDisabled: boolean;
+}
+
+export const FormFractionButtons = ({
+    setRatioAmount,
+    setMax,
+    isDisabled = false,
+}: FormFractionButtonsProps) => (
+    <Flex>
+        <SmallButton isDisabled={isDisabled} onClick={() => setRatioAmount(10)}>
+            10%
+        </SmallButton>
+        <SmallButton isDisabled={isDisabled} onClick={() => setRatioAmount(4)}>
+            25%
+        </SmallButton>
+        <SmallButton isDisabled={isDisabled} onClick={() => setRatioAmount(2)}>
+            50%
+        </SmallButton>
+        <SmallButton isDisabled={isDisabled} onClick={setMax}>
+            <Translation id="TR_STAKE_MAX" />
+        </SmallButton>
+    </Flex>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeEthInANutshellModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeEthInANutshellModal.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import { Button, Icon, IconType, P, useTheme } from '@trezor/components';
 import { Modal, Translation } from 'src/components/suite';
 import { TranslationKey } from '@suite-common/intl-types';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 
 const StyledModal = styled(Modal)`
     width: 380px;
@@ -52,12 +54,18 @@ const STAKING_DETAILS: StakingDetails[] = [
     },
 ];
 
-interface StakingEthInANutshellModalProps {
+interface StakeEthInANutshellModalProps {
     onCancel: () => void;
 }
 
-export const StakingEthInANutshellModal = ({ onCancel }: StakingEthInANutshellModalProps) => {
+export const StakeEthInANutshellModal = ({ onCancel }: StakeEthInANutshellModalProps) => {
     const theme = useTheme();
+
+    const dispatch = useDispatch();
+    const proceedToStaking = () => {
+        onCancel();
+        dispatch(openModal({ type: 'stake' }));
+    };
 
     return (
         <StyledModal
@@ -68,7 +76,7 @@ export const StakingEthInANutshellModal = ({ onCancel }: StakingEthInANutshellMo
                 </HeadingContent>
             }
             bottomBar={
-                <Button fullWidth onClick={onCancel}>
+                <Button fullWidth onClick={proceedToStaking}>
                     <Translation id="TR_GOT_IT" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/AvailableBalance.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/AvailableBalance.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { H3, P, variables } from '@trezor/components';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Translation, FormattedCryptoAmount, FiatValue } from 'src/components/suite';
+
+const Title = styled(H3)`
+    font-size: ${variables.FONT_SIZE.NORMAL};
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const GreyP = styled(P)`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+
+interface AvailableBalanceProps {
+    formattedBalance: string;
+    symbol: NetworkSymbol;
+}
+
+export const AvailableBalance = ({ formattedBalance, symbol }: AvailableBalanceProps) => (
+    <div>
+        <Title>
+            <Translation id="AMOUNT" />
+        </Title>
+
+        <GreyP size="small" weight="medium">
+            <Translation id="TR_STAKE_AVAILABLE" />{' '}
+            <FormattedCryptoAmount value={formattedBalance} symbol={symbol} />{' '}
+            <FiatValue amount={formattedBalance} symbol={symbol} showApproximationIndicator>
+                {({ value }) => (value ? <span>{value}</span> : null)}
+            </FiatValue>
+        </GreyP>
+    </div>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Fees.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Fees.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+import { H3, Icon, P, Tooltip, variables } from '@trezor/components';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { FormattedCryptoAmount, FiatValue, Translation } from 'src/components/suite';
+import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
+import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+
+const Flex = styled.div`
+    display: flex;
+    justify-content: space-between;
+    min-height: 44px;
+`;
+
+const StyledH3 = styled(H3)`
+    font-size: ${variables.FONT_SIZE.NORMAL};
+    line-height: normal;
+`;
+
+const StyledH3Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+const Right = styled.div`
+    text-align: right;
+`;
+
+const GreyP = styled(P)`
+    margin-top: 4px;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+
+export const Fees = () => {
+    const {
+        account: { symbol },
+        composedLevels,
+        selectedFee,
+    } = useStakeEthFormContext();
+    const transactionInfo = composedLevels?.[selectedFee];
+    const isFeeShown = transactionInfo !== undefined && transactionInfo.type !== 'error';
+    const symbolForFiat = mapTestnetSymbol(symbol);
+
+    return (
+        <Flex>
+            <div>
+                <StyledH3Wrapper>
+                    <StyledH3 fontWeight={600}>
+                        <Translation id="MAX_FEE" />
+                    </StyledH3>
+
+                    <Tooltip maxWidth={328} content={<Translation id="TR_STAKE_MAX_FEE_DESC" />}>
+                        {/* TODO: Add new info icon. Export from Figma isn't handled as is it should by the strokes to fills online converter */}
+                        <Icon icon="INFO" size={14} />
+                    </Tooltip>
+                </StyledH3Wrapper>
+            </div>
+
+            <Right>
+                {isFeeShown && (
+                    <>
+                        <P weight="medium">
+                            <FormattedCryptoAmount
+                                disableHiddenPlaceholder
+                                value={formatNetworkAmount(transactionInfo.fee, symbolForFiat)}
+                                symbol={symbolForFiat}
+                            />
+                        </P>
+                        <GreyP size="small" weight="medium">
+                            <FiatValue
+                                disableHiddenPlaceholder
+                                amount={formatNetworkAmount(transactionInfo.fee, symbolForFiat)}
+                                symbol={symbolForFiat}
+                            />
+                        </GreyP>
+                    </>
+                )}
+            </Right>
+        </Flex>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/Inputs.tsx
@@ -1,0 +1,138 @@
+import styled from 'styled-components';
+import { Icon, Warning } from '@trezor/components';
+import { variables } from '@trezor/components/src/config';
+import { getInputState } from '@suite-common/wallet-utils';
+import { useFormatters } from '@suite-common/formatters';
+import { NumberInput, Translation } from 'src/components/suite';
+import { useTranslation } from 'src/hooks/suite';
+import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
+import {
+    validateDecimals,
+    validateInteger,
+    validateLimits,
+    validateMin,
+    validateReserveOrBalance,
+} from 'src/utils/suite/validation';
+import { MAX_LENGTH } from 'src/constants/suite/inputs';
+import { FIAT_INPUT, CRYPTO_INPUT } from 'src/types/wallet/stakeEthForm';
+import { MIN_ETH_FOR_WITHDRAWALS } from 'src/constants/suite/ethStaking';
+
+const VStack = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const StyledIcon = styled(Icon)`
+    transform: rotate(90deg);
+    margin-bottom: 22px;
+`;
+
+const InputAddon = styled.span`
+    text-transform: uppercase;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const StyledWarning = styled(Warning)`
+    margin-top: 12px;
+`;
+
+export const Inputs = () => {
+    const { translationString } = useTranslation();
+    const { CryptoAmountFormatter } = useFormatters();
+
+    const {
+        control,
+        account,
+        network,
+        formState: { errors },
+        getValues,
+        amountLimits,
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        localCurrency,
+        isAmountForWithdrawalWarningShown,
+        isAdviceForWithdrawalWarningShown,
+    } = useStakeEthFormContext();
+
+    const cryptoValue = getValues(CRYPTO_INPUT);
+    const fiatValue = getValues(FIAT_INPUT);
+    const cryptoError = errors.cryptoInput;
+    const fiatError = errors.fiatInput;
+
+    const fiatInputRules = {
+        validate: {
+            min: validateMin(translationString),
+            decimals: validateDecimals(translationString, { decimals: 2 }),
+        },
+    };
+
+    const cryptoInputRules = {
+        required: translationString('AMOUNT_IS_NOT_SET'),
+        validate: {
+            min: validateMin(translationString),
+            integer: validateInteger(translationString, { except: true }),
+            decimals: validateDecimals(translationString, { decimals: network.decimals }),
+            reserveOrBalance: validateReserveOrBalance(translationString, {
+                account,
+            }),
+            limits: validateLimits(translationString, {
+                amountLimits,
+                formatter: CryptoAmountFormatter,
+            }),
+        },
+    };
+
+    return (
+        <VStack>
+            <NumberInput
+                noTopLabel
+                name={FIAT_INPUT}
+                control={control}
+                rules={fiatInputRules}
+                maxLength={MAX_LENGTH.FIAT}
+                innerAddon={<InputAddon>{localCurrency}</InputAddon>}
+                bottomText={errors[FIAT_INPUT]?.message}
+                inputState={getInputState(fiatError || cryptoError, fiatValue)}
+                onChange={value => {
+                    onFiatAmountChange(value);
+                }}
+            />
+
+            {/* TODO: Add new transfer icon. Export from Figma isn't handled as is it should by the strokes to fills online converter */}
+            <StyledIcon icon="TRANSFER" size={16} />
+
+            <NumberInput
+                noTopLabel
+                name={CRYPTO_INPUT}
+                control={control}
+                rules={cryptoInputRules}
+                maxLength={MAX_LENGTH.AMOUNT}
+                innerAddon={<InputAddon>{account.symbol}</InputAddon>}
+                bottomText={errors[CRYPTO_INPUT]?.message}
+                inputState={getInputState(cryptoError || fiatError, cryptoValue)}
+                onChange={value => {
+                    onCryptoAmountChange(value);
+                }}
+            />
+
+            {isAmountForWithdrawalWarningShown && (
+                <StyledWarning variant="info">
+                    <Translation
+                        id="TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL"
+                        values={{ amount: MIN_ETH_FOR_WITHDRAWALS.toString() }}
+                    />
+                </StyledWarning>
+            )}
+            {isAdviceForWithdrawalWarningShown && (
+                <StyledWarning variant="info">
+                    <Translation
+                        id="TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS"
+                        values={{ amount: MIN_ETH_FOR_WITHDRAWALS.toString() }}
+                    />
+                </StyledWarning>
+            )}
+        </VStack>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/index.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+import { Button } from '@trezor/components';
+import { Translation } from 'src/components/suite';
+import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
+import { AvailableBalance } from '../AvailableBalance';
+import { FormFractionButtons } from 'src/components/suite/FormFractionButtons';
+import { Inputs } from './Inputs';
+import { Fees } from './Fees';
+import { isZero } from '@suite-common/wallet-utils';
+
+const Body = styled.div`
+    margin-bottom: 26px;
+`;
+
+const InputsWrapper = styled.div`
+    margin-top: 16px;
+    margin-bottom: 22px;
+`;
+
+const ButtonsWrapper = styled.div`
+    margin-top: 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+export const StakeEthForm = () => {
+    const {
+        account,
+        onSubmit,
+        handleSubmit,
+        formState: { errors, isSubmitting, isDirty },
+        isComposing,
+        setRatioAmount,
+        setMax,
+        watch,
+        clearForm,
+    } = useStakeEthFormContext();
+    const { formattedBalance, symbol } = account;
+    const hasValues = Boolean(watch('fiatInput') || watch('cryptoInput'));
+    // used instead of formState.isValid, which is sometimes returning false even if there are no errors
+    const formIsValid = Object.keys(errors).length === 0;
+    const areFractionButtonsDisabled = isZero(account.formattedBalance);
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)}>
+            <Body>
+                <AvailableBalance formattedBalance={formattedBalance} symbol={symbol} />
+
+                <ButtonsWrapper>
+                    <FormFractionButtons
+                        isDisabled={areFractionButtonsDisabled}
+                        setRatioAmount={setRatioAmount}
+                        setMax={setMax}
+                    />
+
+                    {isDirty && (
+                        <Button type="button" variant="tertiary" onClick={clearForm}>
+                            <Translation id="TR_CLEAR_ALL" />
+                        </Button>
+                    )}
+                </ButtonsWrapper>
+
+                <InputsWrapper>
+                    <Inputs />
+                </InputsWrapper>
+
+                <Fees />
+            </Body>
+
+            <Button
+                fullWidth
+                isDisabled={!(formIsValid && hasValues) || isSubmitting}
+                isLoading={isComposing || isSubmitting}
+                onClick={handleSubmit(onSubmit)}
+            >
+                <Translation id="TR_CONTINUE" />
+            </Button>
+        </form>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModal.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { Modal, Translation } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+import { StakeModalContent } from './StakeModalContent';
+
+const StyledModal = styled(Modal)`
+    // TODO: Make the modal wider when the right section with the graph and staking info is implemented.
+    width: 400px;
+    text-align: left;
+`;
+
+interface StakeModalModalProps {
+    onCancel?: () => void;
+}
+
+export const StakeModal = ({ onCancel }: StakeModalModalProps) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+
+    const { account, status } = selectedAccount;
+    // it shouldn't be possible to open this modal without having selected account
+    if (!account || status !== 'loaded') return null;
+
+    return (
+        <StyledModal isCancelable heading={<Translation id="TR_STAKE_ETH" />} onCancel={onCancel}>
+            <StakeModalContent selectedAccount={selectedAccount} />
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeModalContent.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { StakeEthFormContext, useStakeEthForm } from 'src/hooks/wallet/useStakeEthForm';
+import { StakeEthForm } from './StakeEthForm';
+import { SelectedAccountLoaded } from '@suite-common/wallet-types';
+
+const Flex = styled.div`
+    display: flex;
+    gap: 16px;
+`;
+
+const Left = styled.div`
+    width: 100%;
+`;
+
+interface StakeModalContentProps {
+    selectedAccount: SelectedAccountLoaded;
+}
+
+export const StakeModalContent = ({ selectedAccount }: StakeModalContentProps) => {
+    const stakeEthContextValues = useStakeEthForm({ selectedAccount });
+
+    return (
+        <StakeEthFormContext.Provider value={stakeEthContextValues}>
+            <Flex>
+                <Left>
+                    <StakeEthForm />
+                </Left>
+
+                {/*  TODO: Implement the right section with the rewards graph and staking info  */}
+            </Flex>
+        </StakeEthFormContext.Provider>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -34,7 +34,8 @@ import {
     AuthenticateDeviceModal,
     AuthenticateDeviceFailModal,
     DeviceAuthenticityOptOutModal,
-    StakingEthInANutshellModal,
+    StakeEthInANutshellModal,
+    StakeModal,
 } from 'src/components/suite/modals';
 import type { AcquiredDevice } from 'src/types/suite';
 import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
@@ -203,8 +204,10 @@ export const UserContextModal = ({
             return <AuthenticateDeviceModal />;
         case 'authenticate-device-fail':
             return <AuthenticateDeviceFailModal />;
-        case 'staking-eth-in-a-nutshell':
-            return <StakingEthInANutshellModal onCancel={onCancel} />;
+        case 'stake-eth-in-a-nutshell':
+            return <StakeEthInANutshellModal onCancel={onCancel} />;
+        case 'stake':
+            return <StakeModal onCancel={onCancel} />;
         default:
             return null;
     }

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -40,4 +40,5 @@ export { UnecoCoinjoinModal } from './ReduxModal/UserContextModal/UnecoCoinjoinM
 export { AuthenticateDeviceModal } from './ReduxModal/UserContextModal/AuthenticateDeviceModal';
 export { AuthenticateDeviceFailModal } from './ReduxModal/UserContextModal/AuthenticateDeviceFailModal';
 export { DeviceAuthenticityOptOutModal } from './ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal';
-export { StakingEthInANutshellModal } from './ReduxModal/UserContextModal/StakingEthInANutshellModal';
+export { StakeEthInANutshellModal } from './ReduxModal/UserContextModal/StakeEthInANutshellModal';
+export { StakeModal } from './ReduxModal/UserContextModal/StakeModal/StakeModal';

--- a/packages/suite/src/constants/suite/ethStaking.ts
+++ b/packages/suite/src/constants/suite/ethStaking.ts
@@ -1,3 +1,5 @@
 import BigNumber from 'bignumber.js';
 
-export const MIN_ETH_AMOUNT_FOR_STAKING = new BigNumber(0.103);
+export const MIN_ETH_AMOUNT_FOR_STAKING = new BigNumber(0.1);
+export const MIN_ETH_FOR_WITHDRAWALS = new BigNumber(0.03);
+export const MIN_ETH_BALANCE_FOR_STAKING = MIN_ETH_AMOUNT_FOR_STAKING.plus(MIN_ETH_FOR_WITHDRAWALS);

--- a/packages/suite/src/hooks/wallet/useStakeEthForm.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthForm.ts
@@ -1,0 +1,344 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+
+import BigNumber from 'bignumber.js';
+import useDebounce from 'react-use/lib/useDebounce';
+
+import { fromFiatCurrency, getFeeLevels, toFiatCurrency } from '@suite-common/wallet-utils';
+import { isChanged } from '@suite-common/suite-utils';
+
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import { saveComposedTransactionInfo } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import {
+    StakeEthFormState,
+    UseStakeEthFormProps,
+    StakeEthContextValues,
+    FIAT_INPUT,
+    CRYPTO_INPUT,
+    OUTPUT_AMOUNT,
+} from 'src/types/wallet/stakeEthForm';
+import { mapTestnetSymbol } from 'src/utils/wallet/coinmarket/coinmarketUtils';
+import { useFormDraft } from './useFormDraft';
+import { AmountLimits } from 'src/types/wallet/coinmarketCommonTypes';
+
+import { fromWei } from 'web3-utils';
+import { useStakeEthFormDefaultValues } from './useStakeEthFormDefaultValues';
+import { useCompose } from './form/useCompose';
+import {
+    MIN_ETH_AMOUNT_FOR_STAKING,
+    MIN_ETH_FOR_WITHDRAWALS,
+} from 'src/constants/suite/ethStaking';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
+
+export const StakeEthFormContext = createContext<StakeEthContextValues | null>(null);
+StakeEthFormContext.displayName = 'StakeEthFormContext';
+
+export const useStakeEthForm = ({
+    selectedAccount,
+}: UseStakeEthFormProps): StakeEthContextValues => {
+    const dispatch = useDispatch();
+
+    const fiat = useSelector(state => state.wallet.fiat);
+    const localCurrency = useSelector(selectLocalCurrency);
+    const fees = useSelector(state => state.wallet.fees);
+
+    const { account, network } = selectedAccount;
+    const { symbol } = account;
+
+    const symbolForFiat = mapTestnetSymbol(symbol);
+    const fiatRates = fiat.coins.find(item => item.symbol === symbolForFiat);
+    // TODO: Implement fee switcher
+    const selectedFee = 'normal';
+
+    const amountLimits: AmountLimits = {
+        currency: symbol,
+        minCrypto: MIN_ETH_AMOUNT_FOR_STAKING.toNumber(),
+        maxCrypto: Number(account.formattedBalance),
+    };
+
+    const { saveDraft, getDraft, removeDraft } = useFormDraft<StakeEthFormState>('stake-eth');
+    const draft = getDraft(account.key);
+    const isDraft = !!draft;
+
+    // TODO: Test address. Remove when not needed
+    const to = '0x057f0F0ba2e2f818c6fD4CA4A235F068495B6654';
+    const { defaultValues } = useStakeEthFormDefaultValues(to);
+
+    const state = useMemo(() => {
+        const coinFees = fees[account.symbol];
+        const levels = getFeeLevels(account.networkType, coinFees);
+        const feeInfo = { ...coinFees, levels };
+
+        return {
+            account,
+            network,
+            feeInfo,
+            formValues: defaultValues,
+        };
+    }, [account, defaultValues, fees, network]);
+
+    const methods = useForm<StakeEthFormState>({
+        mode: 'onChange',
+        defaultValues: isDraft ? draft : defaultValues,
+    });
+
+    const { register, control, formState, setValue, reset, clearErrors, getValues, setError } =
+        methods;
+
+    const values = useWatch<StakeEthFormState>({ control });
+
+    useEffect(() => {
+        if (!isChanged(defaultValues, values)) {
+            removeDraft(account.key);
+        }
+    }, [defaultValues, values, removeDraft, account.key]);
+
+    // react-hook-form auto register custom form fields (without HTMLElement)
+    useEffect(() => {
+        register('outputs');
+        register('setMaxOutputId');
+    }, [register]);
+
+    // react-hook-form reset, set default values
+    useEffect(() => {
+        if (!isDraft && defaultValues) {
+            reset(defaultValues);
+        }
+    }, [reset, isDraft, defaultValues]);
+
+    const {
+        isLoading: isComposing,
+        composeRequest,
+        composedLevels,
+    } = useCompose({
+        ...methods,
+        state,
+    });
+
+    useDebounce(
+        () => {
+            if (
+                formState.isDirty &&
+                !formState.isValidating &&
+                Object.keys(formState.errors).length === 0 &&
+                !isComposing
+            ) {
+                saveDraft(selectedAccount.account.key, values as StakeEthFormState);
+            }
+        },
+        200,
+        [
+            saveDraft,
+            selectedAccount.account.key,
+            values,
+            formState.errors,
+            formState.isDirty,
+            formState.isValidating,
+            isComposing,
+        ],
+    );
+
+    const [isAmountForWithdrawalWarningShown, setIsAmountForWithdrawalWarningShown] =
+        useState(false);
+    const [isAdviceForWithdrawalWarningShown, setIsAdviceForWithdrawalWarningShown] =
+        useState(false);
+
+    // TODO: Add more extra fee to ensure tx success when staking logic is implemented
+    const composedFee = useMemo(() => {
+        const transactionInfo = composedLevels?.[selectedFee];
+        return transactionInfo !== undefined && transactionInfo.type !== 'error'
+            ? new BigNumber(fromWei(transactionInfo.fee))
+            : new BigNumber('0');
+    }, [composedLevels]);
+
+    const shouldShowAdvice = useCallback(
+        (amount: string, formattedBalance: string) => {
+            const cryptoValue = new BigNumber(amount);
+            const balance = new BigNumber(formattedBalance);
+            const balanceMinusFee = balance.minus(composedFee);
+
+            if (
+                cryptoValue.gt(balanceMinusFee.minus(MIN_ETH_FOR_WITHDRAWALS)) &&
+                cryptoValue.lt(balanceMinusFee) &&
+                cryptoValue.gt(MIN_ETH_AMOUNT_FOR_STAKING)
+            ) {
+                setIsAdviceForWithdrawalWarningShown(true);
+            }
+        },
+        [composedFee],
+    );
+
+    const onCryptoAmountChange = useCallback(
+        async (amount: string) => {
+            setIsAmountForWithdrawalWarningShown(false);
+            setIsAdviceForWithdrawalWarningShown(false);
+            if (!fiatRates || !fiatRates.current) return;
+
+            const fiatValue = toFiatCurrency(amount, localCurrency, fiatRates.current.rates);
+            setValue('setMaxOutputId', undefined, { shouldDirty: true });
+            setValue(FIAT_INPUT, fiatValue || '', { shouldValidate: true });
+            setValue(OUTPUT_AMOUNT, amount || '', { shouldDirty: true });
+            await composeRequest(CRYPTO_INPUT);
+
+            shouldShowAdvice(amount, account.formattedBalance);
+        },
+        [
+            account.formattedBalance,
+            composeRequest,
+            fiatRates,
+            localCurrency,
+            setValue,
+            shouldShowAdvice,
+        ],
+    );
+
+    const onFiatAmountChange = useCallback(
+        async (amount: string) => {
+            setValue('setMaxOutputId', undefined, { shouldDirty: true });
+            setIsAmountForWithdrawalWarningShown(false);
+            setIsAdviceForWithdrawalWarningShown(false);
+            if (!fiatRates || !fiatRates.current) return;
+
+            const cryptoValue = fromFiatCurrency(
+                amount,
+                localCurrency,
+                fiatRates.current.rates,
+                network.decimals,
+            );
+            setValue(CRYPTO_INPUT, cryptoValue || '', { shouldDirty: true, shouldValidate: true });
+            setValue(OUTPUT_AMOUNT, cryptoValue || '', {
+                shouldDirty: true,
+            });
+            await composeRequest(FIAT_INPUT);
+
+            shouldShowAdvice(cryptoValue || '', account.formattedBalance);
+        },
+        [
+            account.formattedBalance,
+            composeRequest,
+            fiatRates,
+            localCurrency,
+            network.decimals,
+            setValue,
+            shouldShowAdvice,
+        ],
+    );
+
+    const setRatioAmount = useCallback(
+        async (divisor: number) => {
+            setValue('setMaxOutputId', undefined, { shouldDirty: true });
+            clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
+            setIsAmountForWithdrawalWarningShown(false);
+            setIsAdviceForWithdrawalWarningShown(false);
+
+            const amount = new BigNumber(account.formattedBalance)
+                .dividedBy(divisor)
+                .decimalPlaces(network.decimals)
+                .toString();
+
+            await onCryptoAmountChange(amount);
+            setValue(CRYPTO_INPUT, amount, { shouldDirty: true, shouldValidate: true });
+        },
+        [account.formattedBalance, clearErrors, network.decimals, onCryptoAmountChange, setValue],
+    );
+
+    const setMax = useCallback(async () => {
+        setIsAdviceForWithdrawalWarningShown(false);
+        setValue('setMaxOutputId', 0, { shouldDirty: true });
+        clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
+        await composeRequest(CRYPTO_INPUT);
+        setIsAmountForWithdrawalWarningShown(true);
+    }, [clearErrors, composeRequest, setValue]);
+
+    const clearForm = useCallback(async () => {
+        removeDraft(account.key);
+        reset(defaultValues);
+        await composeRequest(CRYPTO_INPUT);
+        setIsAdviceForWithdrawalWarningShown(false);
+        setIsAmountForWithdrawalWarningShown(false);
+    }, [account.key, composeRequest, defaultValues, removeDraft, reset]);
+
+    const { translationString } = useTranslation();
+    useEffect(() => {
+        if (!composedLevels) return;
+        const values = getValues();
+        const { setMaxOutputId } = values;
+        const selectedFeeLevel = selectedFee;
+        const composed = composedLevels[selectedFeeLevel];
+        if (!composed) return;
+
+        if (composed.type === 'final') {
+            if (typeof setMaxOutputId === 'number' && composed.max) {
+                const max = new BigNumber(composed.max).minus(MIN_ETH_FOR_WITHDRAWALS).toString();
+
+                setValue(CRYPTO_INPUT, max, { shouldValidate: true, shouldDirty: true });
+                clearErrors(CRYPTO_INPUT);
+
+                const fiatValue =
+                    fiatRates && fiatRates.current
+                        ? toFiatCurrency(max, localCurrency, fiatRates.current.rates)
+                        : '';
+                setValue(FIAT_INPUT, fiatValue || '', { shouldValidate: true, shouldDirty: true });
+            }
+
+            dispatch(saveComposedTransactionInfo({ selectedFee: selectedFeeLevel, composed }));
+            setValue('estimatedFeeLimit', composed.estimatedFeeLimit, { shouldDirty: true });
+        }
+    }, [
+        clearErrors,
+        composedLevels,
+        dispatch,
+        getValues,
+        setError,
+        setValue,
+        selectedFee,
+        translationString,
+        fiatRates,
+        localCurrency,
+        composedFee,
+        account.formattedBalance,
+    ]);
+
+    const onSubmit = () => {
+        const formValues = methods.getValues();
+        const fiatStringAmount = formValues.fiatInput;
+        const cryptoStringAmount = formValues.cryptoInput;
+
+        const payload = {
+            fiatStringAmount,
+            cryptoStringAmount,
+        };
+
+        console.log(payload);
+    };
+
+    return {
+        ...methods,
+        onSubmit,
+        account,
+        network,
+        cryptoInputValue: values.cryptoInput,
+        removeDraft,
+        formState,
+        isDraft,
+        register,
+        amountLimits,
+        onCryptoAmountChange,
+        onFiatAmountChange,
+        localCurrency,
+        composedLevels,
+        isComposing,
+        setMax,
+        setRatioAmount,
+        isAmountForWithdrawalWarningShown,
+        isAdviceForWithdrawalWarningShown,
+        selectedFee,
+        clearForm,
+    };
+};
+
+export const useStakeEthFormContext = () => {
+    const ctx = useContext(StakeEthFormContext);
+    if (ctx === null) throw Error('useStakeEthFormContext used without Context');
+    return ctx;
+};

--- a/packages/suite/src/hooks/wallet/useStakeEthFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthFormDefaultValues.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+import { StakeEthFormState } from 'src/types/wallet/stakeEthForm';
+
+export const useStakeEthFormDefaultValues = (defaultAddress?: string) => {
+    const defaultValues = useMemo(
+        () =>
+            ({
+                ...DEFAULT_VALUES,
+                estimatedFeeLimit: undefined,
+                fiatInput: '',
+                cryptoInput: '',
+                outputs: [
+                    {
+                        ...DEFAULT_PAYMENT,
+                        address: defaultAddress,
+                    },
+                ],
+                options: ['broadcast'],
+            }) as StakeEthFormState,
+        [defaultAddress],
+    );
+
+    return { defaultValues };
+};

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,7 +1,7 @@
 import { accountsActions } from '@suite-common/wallet-core';
 import type { Action } from 'src/types/suite';
 import type { SelectedAccountStatus } from '@suite-common/wallet-types';
-import { MIN_ETH_AMOUNT_FOR_STAKING } from 'src/constants/suite/ethStaking';
+import { MIN_ETH_BALANCE_FOR_STAKING } from 'src/constants/suite/ethStaking';
 
 export type State = SelectedAccountStatus;
 
@@ -37,7 +37,7 @@ export const selectSelectedAccountHasSufficientEthForStaking = (
 
     if (typeof formattedBalance !== 'string' || symbol !== 'eth') return false;
 
-    return MIN_ETH_AMOUNT_FOR_STAKING.isLessThanOrEqualTo(formattedBalance);
+    return MIN_ETH_BALANCE_FOR_STAKING.isLessThanOrEqualTo(formattedBalance);
 };
 
 export default selectedAccountReducer;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8329,4 +8329,27 @@ export default defineMessages({
         id: 'TR_ETH_REWARDS_EARN',
         defaultMessage: 'Your rewards also earn. Keep them staked and watch your ETH rewards soar.',
     },
+    TR_STAKE_AVAILABLE: {
+        id: 'TR_STAKE_AVAILABLE',
+        defaultMessage: 'Available',
+    },
+    TR_STAKE_MAX_FEE_DESC: {
+        id: 'TR_STAKE_MAX_FEE_DESC',
+        defaultMessage:
+            'Maximum fee is the network transaction fee that you’re willing to pay on the network to ensure your transaction gets processed.',
+    },
+    TR_STAKE_MAX: {
+        id: 'TR_STAKE_MAX',
+        defaultMessage: 'Max',
+    },
+    TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL: {
+        id: 'TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL',
+        defaultMessage:
+            'We’ve left {amount} ETH out so you will be able to pay for withdrawal fees',
+    },
+    TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS: {
+        id: 'TR_STAKE_RECOMMENDED_AMOUNT_FOR_WITHDRAWALS',
+        defaultMessage:
+            'We recommend you to leave {amount} ETH so you will be able to pay for withdrawal fees',
+    },
 });

--- a/packages/suite/src/types/wallet/stakeEthForm.ts
+++ b/packages/suite/src/types/wallet/stakeEthForm.ts
@@ -1,0 +1,47 @@
+import { UseFormReturn } from 'react-hook-form';
+import {
+    Account,
+    FormState,
+    PrecomposedLevels,
+    PrecomposedLevelsCardano,
+} from '@suite-common/wallet-types';
+import { Network } from './index';
+import { FormState as ReactHookFormState } from 'react-hook-form/dist/types/form';
+import { AmountLimits } from './coinmarketCommonTypes';
+import { FiatCurrencyCode } from '@suite-common/suite-config';
+import { WithSelectedAccountLoadedProps } from '../../components/wallet';
+import { FeeLevel } from '@trezor/connect';
+
+export const FIAT_INPUT = 'fiatInput';
+export const CRYPTO_INPUT = 'cryptoInput';
+export const OUTPUT_AMOUNT = 'outputs.0.amount';
+
+export type UseStakeEthFormProps = WithSelectedAccountLoadedProps;
+
+export interface StakeEthFormState extends FormState {
+    fiatInput?: string;
+    cryptoInput?: string;
+}
+
+export type StakeEthContextValues = UseFormReturn<StakeEthFormState> & {
+    onSubmit: () => void;
+    account: Account;
+    network: Network;
+    cryptoInputValue?: string;
+    removeDraft: (key: string) => void;
+    formState: ReactHookFormState<StakeEthFormState>;
+    isDraft: boolean;
+    amountLimits: AmountLimits;
+    onCryptoAmountChange: (amount: string) => void;
+    onFiatAmountChange: (amount: string) => void;
+    localCurrency: FiatCurrencyCode;
+    composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
+    isComposing: boolean;
+    setMax: () => void;
+    setRatioAmount: (divisor: number) => void;
+    isAmountForWithdrawalWarningShown: boolean;
+    isAdviceForWithdrawalWarningShown: boolean;
+    // TODO: Implement fee switcher
+    selectedFee: FeeLevel['label'];
+    clearForm: () => void;
+};

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -43,7 +43,7 @@ export const validateInteger =
 
 interface ValidateLimitsOptions {
     amountLimits?: AmountLimits;
-    areSatsUsed: boolean;
+    areSatsUsed?: boolean;
     formatter: Formatter<string, string>;
 }
 
@@ -100,7 +100,7 @@ export const validateMin =
 
 interface ValidateReserveOrBalanceOptions {
     account: Account;
-    areSatsUsed: boolean;
+    areSatsUsed?: boolean;
     tokenAddress?: string | null;
 }
 

--- a/packages/suite/src/views/dashboard/components/StakeEthCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/StakeEthCard/index.tsx
@@ -6,7 +6,7 @@ import { Translation, Card, StakingFeature } from 'src/components/suite';
 import { Footer } from './components/Footer';
 import { useDiscovery } from 'src/hooks/suite';
 import { useAccounts } from 'src/hooks/wallet';
-import { MIN_ETH_AMOUNT_FOR_STAKING } from 'src/constants/suite/ethStaking';
+import { MIN_ETH_BALANCE_FOR_STAKING } from 'src/constants/suite/ethStaking';
 
 const Flex = styled.div`
     display: flex;
@@ -68,7 +68,7 @@ export const StakeEthCard = () => {
     const { accounts } = useAccounts(discovery);
     const ethAccountWithSufficientBalanceForStaking = accounts.find(
         ({ symbol, formattedBalance }) =>
-            symbol === 'eth' && MIN_ETH_AMOUNT_FOR_STAKING.isLessThanOrEqualTo(formattedBalance),
+            symbol === 'eth' && MIN_ETH_BALANCE_FOR_STAKING.isLessThanOrEqualTo(formattedBalance),
     );
     const isSufficientEthForStaking = Boolean(
         ethAccountWithSufficientBalanceForStaking?.formattedBalance,

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EmptyStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/components/EmptyStakingCard.tsx
@@ -53,7 +53,7 @@ export const EmptyStakingCard = () => {
 
     const dispatch = useDispatch();
     const openStakingEthInANutshellModal = () =>
-        dispatch(openModal({ type: 'staking-eth-in-a-nutshell' }));
+        dispatch(openModal({ type: 'stake-eth-in-a-nutshell' }));
 
     const stakeEthFeatures = [
         {

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -167,5 +167,8 @@ export type UserContextPayload =
           type: 'authenticate-device-fail';
       }
     | {
-          type: 'staking-eth-in-a-nutshell';
+          type: 'stake-eth-in-a-nutshell';
+      }
+    | {
+          type: 'stake';
       };

--- a/suite-common/wallet-constants/src/formDraft.ts
+++ b/suite-common/wallet-constants/src/formDraft.ts
@@ -4,4 +4,5 @@ export const FormDraftPrefixKeyValues = [
     'coinmarket-exchange',
     'coinmarket-p2p',
     'coinmarket-savings-setup-request',
+    'stake-eth',
 ] as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The "Stake Ethereum" modal is implemented.

This PR covers basic layout and logic of the form for staking ETH. It's a combination of two issues: "Lite staking: Stake variable amount" and "Staking: Stake Min/Max + ETH to Fiat pairing". It mainly concerns a new `useStakeEthForm` context, namely input validations, crypto-fiat/fiat-crypto conversions, fee calculation, setting fractions of user's available amount, additional warning. This context will keep extending when the staking logic itself is added and more logic is required.

## Related Issue

Resolve <!--- link the issue here -->
https://github.com/trezor/trezor-suite/issues/9220
https://github.com/trezor/trezor-suite/issues/9255

## Screenshots:
<img width="1511" alt="Знімок екрана 2023-12-04 о 13 46 28" src="https://github.com/everstake/trezor-suite/assets/42133844/587b2afa-022d-4cb3-bbb4-788b2bf325ed">
