### PR TITLE
feat(eth-staking): add confirm and sign tx modals

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,0 +1,282 @@
+import BigNumber from 'bignumber.js';
+import { toWei } from 'web3-utils';
+
+import TrezorConnect, { FeeLevel } from '@trezor/connect';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    calculateTotal,
+    calculateMax,
+    calculateEthFee,
+    getEthereumEstimateFeeParams,
+    prepareEthereumTransaction,
+    getExternalComposeOutput,
+    formatAmount,
+    isPending,
+} from '@suite-common/wallet-utils';
+import { ETH_DEFAULT_GAS_LIMIT, ERC20_GAS_LIMIT } from '@suite-common/wallet-constants';
+import {
+    StakeFormState,
+    ComposeActionContext,
+    PrecomposedLevels,
+    PrecomposedTransaction,
+    PrecomposedTransactionFinal,
+    ExternalOutput,
+} from '@suite-common/wallet-types';
+import { selectDevice } from '@suite-common/wallet-core';
+
+import { Dispatch, GetState } from 'src/types/suite';
+import { AddressDisplayOptions, selectAddressDisplayType } from 'src/reducers/suite/suiteReducer';
+
+const calculate = (
+    availableBalance: string,
+    output: ExternalOutput,
+    feeLevel: FeeLevel,
+): PrecomposedTransaction => {
+    const feeInSatoshi = calculateEthFee(
+        toWei(feeLevel.feePerUnit, 'gwei'),
+        feeLevel.feeLimit || '0',
+    );
+
+    let amount: string;
+    let max: string | undefined;
+
+    if (output.type === 'send-max' || output.type === 'send-max-noaddress') {
+        max = calculateMax(availableBalance, feeInSatoshi);
+        amount = max;
+    } else {
+        amount = output.amount;
+    }
+
+    // total ETH spent (amount + fee), in ERC20 only fee
+    const totalSpent = new BigNumber(calculateTotal(amount, feeInSatoshi));
+
+    if (totalSpent.isGreaterThan(availableBalance)) {
+        const error = 'AMOUNT_IS_NOT_ENOUGH';
+        // errorMessage declared later
+        return { type: 'error', error, errorMessage: { id: error } } as const;
+    }
+
+    const payloadData = {
+        type: 'nonfinal' as const,
+        totalSpent: totalSpent.toString(),
+        max,
+        fee: feeInSatoshi,
+        feePerByte: feeLevel.feePerUnit,
+        feeLimit: feeLevel.feeLimit,
+        bytes: 0, // TODO: calculate
+        inputs: [],
+    };
+
+    if (output.type === 'send-max' || output.type === 'payment') {
+        return {
+            ...payloadData,
+            type: 'final',
+            // compatibility with BTC PrecomposedTransaction from @trezor/connect
+            inputs: [],
+            outputsPermutation: [0],
+            outputs: [
+                {
+                    address: output.address,
+                    amount,
+                    script_type: 'PAYTOADDRESS',
+                },
+            ],
+        };
+    }
+    return payloadData;
+};
+
+export const composeTransaction =
+    (formValues: StakeFormState, formState: ComposeActionContext) => async () => {
+        const { account, network, feeInfo } = formState;
+        const composeOutputs = getExternalComposeOutput(formValues, account, network);
+        if (!composeOutputs) return; // no valid Output
+
+        const { output, tokenInfo, decimals } = composeOutputs;
+        const { availableBalance } = account;
+        const { address, amount } = formValues.outputs[0];
+
+        let customFeeLimit: string | undefined;
+        // set gasLimit based on ERC20 transfer
+        if (tokenInfo) {
+            customFeeLimit = ERC20_GAS_LIMIT;
+        }
+
+        // gasLimit calculation based on address, amount and data size
+        // amount in essential for a proper calculation of gasLimit (via blockbook/geth)
+        const estimatedFee = await TrezorConnect.blockchainEstimateFee({
+            coin: account.symbol,
+            request: {
+                blocks: [2],
+                specific: {
+                    from: account.descriptor,
+                    ...getEthereumEstimateFeeParams(
+                        address || account.descriptor,
+                        // if amount is not set (set-max case) use max available balance
+                        amount || (tokenInfo ? tokenInfo.balance! : account.formattedBalance),
+                        tokenInfo,
+                        formValues.ethereumDataHex,
+                    ),
+                },
+            },
+        });
+
+        if (estimatedFee.success) {
+            customFeeLimit = estimatedFee.payload.levels[0].feeLimit;
+            if (formValues.ethereumAdjustGasLimit && customFeeLimit) {
+                customFeeLimit = new BigNumber(customFeeLimit)
+                    .multipliedBy(new BigNumber(formValues.ethereumAdjustGasLimit))
+                    .toFixed(0);
+            }
+        } else {
+            // TODO: catch error from blockbook/geth (invalid contract, not enough balance...)
+        }
+
+        // FeeLevels are read-only
+        const levels = customFeeLimit ? feeInfo.levels.map(l => ({ ...l })) : feeInfo.levels;
+        const predefinedLevels = levels.filter(l => l.label !== 'custom');
+        // update predefined levels with customFeeLimit (gasLimit from data size or erc20 transfer)
+        if (customFeeLimit) {
+            predefinedLevels.forEach(l => (l.feeLimit = customFeeLimit));
+        }
+        // in case when selectedFee is set to 'custom' construct this FeeLevel from values
+        if (formValues.selectedFee === 'custom') {
+            predefinedLevels.push({
+                label: 'custom',
+                feePerUnit: formValues.feePerUnit,
+                feeLimit: formValues.feeLimit,
+                blocks: -1,
+            });
+        }
+
+        // wrap response into PrecomposedLevels object where key is a FeeLevel label
+        const wrappedResponse: PrecomposedLevels = {};
+        const response = predefinedLevels.map(level => calculate(availableBalance, output, level));
+        response.forEach((tx, index) => {
+            const feeLabel = predefinedLevels[index].label as FeeLevel['label'];
+            wrappedResponse[feeLabel] = tx;
+        });
+
+        const hasAtLeastOneValid = response.find(r => r.type !== 'error');
+        // there is no valid tx in predefinedLevels and there is no custom level
+        if (!hasAtLeastOneValid && !wrappedResponse.custom) {
+            const { minFee } = feeInfo;
+            const lastKnownFee = predefinedLevels[predefinedLevels.length - 1].feePerUnit;
+            let maxFee = new BigNumber(lastKnownFee).minus(1);
+            // generate custom levels in range from lastKnownFee - 1 to feeInfo.minFee (coinInfo in @trezor/connect)
+            const customLevels: FeeLevel[] = [];
+            while (maxFee.gte(minFee)) {
+                customLevels.push({
+                    feePerUnit: maxFee.toString(),
+                    feeLimit: predefinedLevels[0].feeLimit,
+                    label: 'custom',
+                    blocks: -1,
+                });
+                maxFee = maxFee.minus(1);
+            }
+
+            // check if any custom level is possible
+            const customLevelsResponse = customLevels.map(level =>
+                calculate(availableBalance, output, level),
+            );
+
+            const customValid = customLevelsResponse.findIndex(r => r.type !== 'error');
+            if (customValid >= 0) {
+                wrappedResponse.custom = customLevelsResponse[customValid];
+            }
+        }
+
+        // format max (calculate sends it as satoshi)
+        // update errorMessage values (symbol)
+        Object.keys(wrappedResponse).forEach(key => {
+            const tx = wrappedResponse[key];
+            if (tx.type !== 'error') {
+                tx.max = tx.max ? formatAmount(tx.max, decimals) : undefined;
+                tx.estimatedFeeLimit = customFeeLimit;
+            }
+            if (tx.type === 'error' && tx.error === 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE') {
+                tx.errorMessage = {
+                    id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                    values: { symbol: network.symbol.toUpperCase() },
+                };
+            }
+        });
+
+        return wrappedResponse;
+    };
+
+export const signTransaction =
+    (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const { selectedAccount, transactions } = getState().wallet;
+        const device = selectDevice(getState());
+        if (
+            selectedAccount.status !== 'loaded' ||
+            !device ||
+            !transactionInfo ||
+            transactionInfo.type !== 'final'
+        )
+            return;
+
+        const { account, network } = selectedAccount;
+        if (account.networkType !== 'ethereum' || !network.chainId) return;
+
+        const addressDisplayType = selectAddressDisplayType(getState());
+
+        // Ethereum account `misc.nonce` is not updated before pending tx is mined
+        // Calculate `pendingNonce`: greatest value in pending tx + 1
+        // This may lead to unexpected/unwanted behavior
+        // whenever pending tx gets rejected all following txs (with higher nonce) will be rejected as well
+        const pendingTxs = (transactions.transactions[account.key] || []).filter(isPending);
+        const pendingNonce = pendingTxs.reduce((value, tx) => {
+            if (!tx.ethereumSpecific) return value;
+            return Math.max(value, tx.ethereumSpecific.nonce + 1);
+        }, 0);
+        const pendingNonceBig = new BigNumber(pendingNonce);
+        let nonce =
+            pendingNonceBig.gt(0) && pendingNonceBig.gt(account.misc.nonce)
+                ? pendingNonceBig.toString()
+                : account.misc.nonce;
+
+        if (formValues.rbfParams && typeof formValues.rbfParams.ethereumNonce === 'number') {
+            nonce = formValues.rbfParams.ethereumNonce.toString();
+        }
+
+        // transform to TrezorConnect.ethereumSignTransaction params
+        const transaction = prepareEthereumTransaction({
+            token: transactionInfo.token,
+            chainId: network.chainId,
+            to: formValues.outputs[0].address,
+            amount: formValues.outputs[0].amount,
+            data: formValues.ethereumDataHex,
+            gasLimit: transactionInfo.feeLimit || ETH_DEFAULT_GAS_LIMIT,
+            gasPrice: transactionInfo.feePerByte,
+            nonce,
+        });
+
+        const signedTx = await TrezorConnect.ethereumSignTransaction({
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state,
+            },
+            useEmptyPassphrase: device.useEmptyPassphrase,
+            path: account.path,
+            transaction,
+            chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
+        });
+
+        if (!signedTx.success) {
+            // catch manual error from TransactionReviewModal
+            if (signedTx.payload.error === 'tx-cancelled') return;
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: signedTx.payload.error,
+                }),
+            );
+            return;
+        }
+
+        return signedTx.payload.serializedTx;
+    };

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,0 +1,177 @@
+import BigNumber from 'bignumber.js';
+
+import TrezorConnect, { SignedTransaction } from '@trezor/connect';
+import {
+    selectDevice,
+    replaceTransactionThunk,
+    syncAccountsWithBlockchainThunk,
+    stakeActions,
+} from '@suite-common/wallet-core';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+
+import {
+    StakeFormState,
+    PrecomposedTransactionFinal,
+    ComposeActionContext,
+} from '@suite-common/wallet-types';
+
+import * as modalActions from '../suite/modalActions';
+import { Dispatch, GetState } from 'src/types/suite';
+
+import * as stakeFormEthereumActions from './stake/stakeFormEthereumActions';
+import { openModal } from '../suite/modalActions';
+
+export const composeTransaction =
+    (formValues: StakeFormState, formState: ComposeActionContext) => (dispatch: Dispatch) => {
+        const { account } = formState;
+        if (account.networkType === 'ethereum') {
+            return dispatch(stakeFormEthereumActions.composeTransaction(formValues, formState));
+        }
+        return Promise.resolve(undefined);
+    };
+
+// this could be called at any time during signTransaction or pushTransaction process (from TransactionReviewModal)
+export const cancelSignTx = () => (dispatch: Dispatch, getState: GetState) => {
+    const { signedTx } = getState().wallet.stake;
+    dispatch(stakeActions.requestSignTransaction());
+    dispatch(stakeActions.requestPushTransaction());
+    // if transaction is not signed yet interrupt signing in TrezorConnect
+    if (!signedTx) {
+        TrezorConnect.cancel('tx-cancelled');
+        return;
+    }
+    // otherwise just close modal and open stake modal
+    dispatch(modalActions.onCancel());
+    dispatch(openModal({ type: 'stake' }));
+};
+
+// private, called from signTransaction only
+const pushTransaction =
+    (signedTransaction: SignedTransaction['signedTransaction']) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const { signedTx, precomposedTx } = getState().wallet.stake;
+        const { account } = getState().wallet.selectedAccount;
+        const device = selectDevice(getState());
+        if (!signedTx || !precomposedTx || !account) return;
+
+        const sentTx = await TrezorConnect.pushTransaction(signedTx);
+        // const sentTx = { success: true, payload: { txid: 'ABC ' } };
+
+        // close modal regardless result
+        dispatch(modalActions.onCancel());
+
+        const spentWithoutFee = new BigNumber(precomposedTx.totalSpent)
+            .minus(precomposedTx.fee)
+            .toString();
+
+        // get total amount without fee
+        const formattedAmount = formatNetworkAmount(spentWithoutFee, account.symbol, true, false);
+
+        if (sentTx.success) {
+            const { txid } = sentTx.payload;
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'tx-sent',
+                    formattedAmount,
+                    device,
+                    descriptor: account.descriptor,
+                    symbol: account.symbol,
+                    txid,
+                }),
+            );
+
+            if (precomposedTx.prevTxid) {
+                // notification from the backend may be delayed.
+                // modify affected transaction(s) in the reducer until the real account update occurs.
+                // this will update transaction details (like time, fee etc.)
+                dispatch(
+                    replaceTransactionThunk({
+                        precomposedTx,
+                        newTxid: txid,
+                        signedTransaction,
+                    }),
+                );
+            }
+
+            // notification from the backend may be delayed.
+            // modify affected account balance.
+            // TODO: make it work with ETH accounts
+
+            // there is no point in fetching account data right after tx submit
+            //  as the account will update only after the tx is confirmed
+            dispatch(syncAccountsWithBlockchainThunk(account.symbol));
+        } else {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error: sentTx.payload.error,
+                }),
+            );
+        }
+
+        dispatch(cancelSignTx());
+
+        // resolve sign process
+        return sentTx;
+    };
+
+export const signTransaction =
+    (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const device = selectDevice(getState());
+        const { account } = getState().wallet.selectedAccount;
+
+        if (!device || !account) return;
+
+        const enhancedTxInfo: PrecomposedTransactionFinal = {
+            ...transactionInfo,
+            rbf: false,
+        };
+
+        // store formValues and transactionInfo in send reducer to be used by TransactionReviewModal
+        dispatch(
+            stakeActions.requestSignTransaction({
+                formValues,
+                transactionInfo: enhancedTxInfo,
+            }),
+        );
+
+        // TransactionReviewModal has 2 steps: signing and pushing
+        // TrezorConnect emits UI.CLOSE_UI.WINDOW after the signing process
+        // this action is blocked by modalActions.preserve()
+        dispatch(modalActions.preserve());
+
+        // signTransaction by Trezor
+        let serializedTx: string | undefined;
+        let signedTransaction: SignedTransaction['signedTransaction'];
+        if (account.networkType === 'ethereum') {
+            serializedTx = await dispatch(
+                stakeFormEthereumActions.signTransaction(formValues, enhancedTxInfo),
+            );
+        }
+
+        if (!serializedTx) {
+            // close modal manually since UI.CLOSE_UI.WINDOW was blocked
+            dispatch(modalActions.onCancel());
+            dispatch(openModal({ type: 'stake' }));
+            return;
+        }
+
+        // store serializedTx in reducer (TrezorConnect.pushTransaction params) to be used in TransactionReviewModal and pushTransaction method
+        dispatch(
+            stakeActions.requestPushTransaction({
+                tx: serializedTx,
+                coin: account.symbol,
+            }),
+        );
+
+        // Open a deferred modal and get the decision
+        const decision = await dispatch(
+            modalActions.openDeferredModal({ type: 'review-transaction' }),
+        );
+        if (decision) {
+            // push tx to the network
+            return dispatch(pushTransaction(signedTransaction));
+        }
+    };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,30 +1,9 @@
-import { useState } from 'react';
-import styled from 'styled-components';
-
-import { ConfirmOnDevice, variables } from '@trezor/components';
-import { DeviceModelInternal } from '@trezor/connect';
 import { UserContextPayload } from '@suite-common/suite-types';
-import { selectDevice } from '@suite-common/wallet-core';
-import { Translation, Modal } from 'src/components/suite';
-import { useDispatch, useSelector } from 'src/hooks/suite';
-import { cancelSignTx } from 'src/actions/wallet/sendFormActions';
-import { isCardanoTx } from '@suite-common/wallet-utils';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
-import { constructOutputs } from 'src/utils/wallet/reviewTransactionUtils';
-import { TransactionReviewSummary } from './TransactionReviewSummary';
-import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
-
-const StyledModal = styled(Modal)`
-    ${Modal.Body} {
-        padding: 10px;
-        margin-bottom: 0;
-    }
-    ${Modal.Content} {
-        @media (min-width: ${variables.SCREEN_SIZE.SM}) {
-            flex-direction: row;
-        }
-    }
-`;
+import { selectStake } from '@suite-common/wallet-core';
+import { useSelector } from 'src/hooks/suite';
+import { cancelSignTx as cancelSignSendTx } from 'src/actions/wallet/sendFormActions';
+import { cancelSignTx as cancelSignStakingTx } from 'src/actions/wallet/stakeActions';
+import { TransactionReviewModalContent } from './TransactionReviewModalContent';
 
 // This modal is opened either in Device (button request) or User (push tx) context
 // contexts are distinguished by `type` prop
@@ -33,115 +12,19 @@ type TransactionReviewModalProps =
     | { type: 'sign-transaction'; decision?: undefined };
 
 export const TransactionReviewModal = ({ decision }: TransactionReviewModalProps) => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const send = useSelector(state => state.wallet.send);
-    const fees = useSelector(state => state.wallet.fees);
-    const device = useSelector(selectDevice);
-    const isActionAbortable = useSelector(selectIsActionAbortable);
-    const dispatch = useDispatch();
+    const stake = useSelector(selectStake);
 
-    const [detailsOpen, setDetailsOpen] = useState(false);
-
-    const deviceModelInternal = device?.features?.internal_model;
-
-    const { precomposedTx, precomposedForm, signedTx } = send;
-
-    if (selectedAccount.status !== 'loaded' || !device || !precomposedTx || !precomposedForm) {
-        return null;
-    }
-
-    const { account } = selectedAccount;
-    const { networkType } = account;
-    const isCardano = isCardanoTx(account, precomposedTx);
-    const isEthereum = networkType === 'ethereum';
-    const isRbfAction = !!precomposedTx.prevTxid;
-    const decreaseOutputId = precomposedTx.useNativeRbf
-        ? precomposedForm.setMaxOutputId
-        : undefined;
-
-    const outputs = constructOutputs({
-        account,
-        decreaseOutputId,
-        device,
-        precomposedForm,
-        precomposedTx,
-    });
-
-    // omit other button requests (like passphrase)
-    const buttonRequests = device.buttonRequests.filter(
-        ({ code }) =>
-            code === 'ButtonRequest_ConfirmOutput' ||
-            code === 'ButtonRequest_SignTx' ||
-            (code === 'ButtonRequest_Other' && (isCardano || isEthereum)), // Cardano and Ethereum are using ButtonRequest_Other
-    );
-
-    // NOTE: T1B1 edge-case
-    // while confirming decrease amount 'ButtonRequest_ConfirmOutput' is called twice (confirm decrease address, confirm decrease amount)
-    // remove 1 additional element to keep it consistent with T2T1 where this step is swipeable with one button request
-    if (
-        typeof decreaseOutputId === 'number' &&
-        deviceModelInternal === DeviceModelInternal.T1B1 &&
-        buttonRequests.filter(r => r.code === 'ButtonRequest_ConfirmOutput').length > 1
-    ) {
-        buttonRequests.splice(-1, 1);
-    }
-
-    // get estimate mining time
-    let estimateTime;
-    const selected = fees[selectedAccount.account.symbol];
-    const matchedFeeLevel = selected.levels.find(
-        item => item.feePerUnit === precomposedTx.feePerByte,
-    );
-
-    if (networkType === 'bitcoin' && matchedFeeLevel) {
-        estimateTime = selected.blockTime * matchedFeeLevel.blocks * 60;
-    }
-
-    const buttonRequestsCount = isCardano ? buttonRequests.length - 1 : buttonRequests.length;
-
-    const onCancel =
-        isActionAbortable || signedTx
-            ? () => {
-                  dispatch(cancelSignTx());
-                  decision?.resolve(false);
-              }
-            : undefined;
+    const isSend = Boolean(send?.precomposedTx);
+    // Only one state should be available when the modal is open
+    const txInfoState = isSend ? send : stake;
+    const cancelSignTx = isSend ? cancelSignSendTx : cancelSignStakingTx;
 
     return (
-        <StyledModal
-            modalPrompt={
-                <ConfirmOnDevice
-                    title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                    steps={outputs.length + 1}
-                    activeStep={signedTx ? outputs.length + 2 : buttonRequestsCount}
-                    deviceModelInternal={deviceModelInternal}
-                    deviceUnitColor={device?.features?.unit_color}
-                    successText={<Translation id="TR_CONFIRMED_TX" />}
-                    onCancel={onCancel}
-                />
-            }
-        >
-            <TransactionReviewSummary
-                estimateTime={estimateTime}
-                tx={precomposedTx}
-                account={selectedAccount.account}
-                network={selectedAccount.network}
-                broadcast={precomposedForm.options.includes('broadcast')}
-                detailsOpen={detailsOpen}
-                isRbfAction={isRbfAction}
-                onDetailsClick={() => setDetailsOpen(!detailsOpen)}
-            />
-            <TransactionReviewOutputList
-                account={selectedAccount.account}
-                precomposedForm={precomposedForm}
-                precomposedTx={precomposedTx}
-                signedTx={signedTx}
-                decision={decision}
-                detailsOpen={detailsOpen}
-                outputs={outputs}
-                buttonRequestsCount={buttonRequestsCount}
-                isRbfAction={isRbfAction}
-            />
-        </StyledModal>
+        <TransactionReviewModalContent
+            decision={decision}
+            txInfoState={txInfoState}
+            cancelSignTx={cancelSignTx}
+        />
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalContent.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { ConfirmOnDevice, variables } from '@trezor/components';
+import { DeviceModelInternal } from '@trezor/protobuf/lib/messages';
+import { Deferred } from '@trezor/utils';
+import { selectDevice, StakeState } from '@suite-common/wallet-core';
+import { isCardanoTx } from '@suite-common/wallet-utils';
+import { SendState } from 'src/reducers/wallet/sendFormReducer';
+import { Dispatch, GetState } from 'src/types/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { constructOutputs } from 'src/utils/wallet/reviewTransactionUtils';
+import { getTransactionReviewModalActionText } from 'src/utils/suite/transactionReview';
+import { Modal, Translation } from 'src/components/suite';
+import { TransactionReviewSummary } from './TransactionReviewSummary';
+import { TransactionReviewOutputList } from './TransactionReviewOutputList/TransactionReviewOutputList';
+
+const StyledModal = styled(Modal)`
+    ${Modal.Body} {
+        padding: 10px;
+        margin-bottom: 0;
+    }
+    ${Modal.Content} {
+        @media (min-width: ${variables.SCREEN_SIZE.SM}) {
+            flex-direction: row;
+        }
+    }
+`;
+
+interface TransactionReviewModalContentProps {
+    decision: Deferred<boolean, string | number | undefined> | undefined;
+    txInfoState: SendState | StakeState;
+    cancelSignTx: () => (dispatch: Dispatch, getState: GetState) => void;
+}
+
+export const TransactionReviewModalContent = ({
+    decision,
+    txInfoState,
+    cancelSignTx,
+}: TransactionReviewModalContentProps) => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const fees = useSelector(state => state.wallet.fees);
+    const device = useSelector(selectDevice);
+    const isActionAbortable = useSelector(selectIsActionAbortable);
+    const dispatch = useDispatch();
+    const [detailsOpen, setDetailsOpen] = useState(false);
+
+    const deviceModelInternal = device?.features?.internal_model;
+
+    const { precomposedTx, precomposedForm, signedTx } = txInfoState;
+
+    if (selectedAccount.status !== 'loaded' || !device || !precomposedTx || !precomposedForm) {
+        return null;
+    }
+
+    const { account } = selectedAccount;
+    const { networkType } = account;
+    const isCardano = isCardanoTx(account, precomposedTx);
+    const isEthereum = networkType === 'ethereum';
+    const isRbfAction = !!precomposedTx.prevTxid;
+    const decreaseOutputId = precomposedTx.useNativeRbf
+        ? precomposedForm.setMaxOutputId
+        : undefined;
+
+    const outputs = constructOutputs({
+        account,
+        decreaseOutputId,
+        device,
+        precomposedForm,
+        precomposedTx,
+    });
+
+    const ethereumStakeType =
+        'ethereumStakeType' in precomposedForm ? precomposedForm.ethereumStakeType : null;
+    const actionText = getTransactionReviewModalActionText({
+        ethereumStakeType,
+        isRbfAction,
+    });
+
+    // omit other button requests (like passphrase)
+    const buttonRequests = device.buttonRequests.filter(
+        ({ code }) =>
+            code === 'ButtonRequest_ConfirmOutput' ||
+            code === 'ButtonRequest_SignTx' ||
+            (code === 'ButtonRequest_Other' && (isCardano || isEthereum)), // Cardano and Ethereum are using ButtonRequest_Other
+    );
+
+    // NOTE: T1B1 edge-case
+    // while confirming decrease amount 'ButtonRequest_ConfirmOutput' is called twice (confirm decrease address, confirm decrease amount)
+    // remove 1 additional element to keep it consistent with T2T1 where this step is swipeable with one button request
+    if (
+        typeof decreaseOutputId === 'number' &&
+        deviceModelInternal === DeviceModelInternal.T1B1 &&
+        buttonRequests.filter(r => r.code === 'ButtonRequest_ConfirmOutput').length > 1
+    ) {
+        buttonRequests.splice(-1, 1);
+    }
+
+    // get estimate mining time
+    let estimateTime;
+    const selected = fees[selectedAccount.account.symbol];
+    const matchedFeeLevel = selected.levels.find(
+        item => item.feePerUnit === precomposedTx.feePerByte,
+    );
+
+    if (networkType === 'bitcoin' && matchedFeeLevel) {
+        estimateTime = selected.blockTime * matchedFeeLevel.blocks * 60;
+    }
+
+    const buttonRequestsCount = isCardano ? buttonRequests.length - 1 : buttonRequests.length;
+
+    const onCancel =
+        isActionAbortable || signedTx
+            ? () => {
+                  dispatch(cancelSignTx());
+                  decision?.resolve(false);
+              }
+            : undefined;
+
+    return (
+        <StyledModal
+            modalPrompt={
+                <ConfirmOnDevice
+                    title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                    steps={outputs.length + 1}
+                    activeStep={signedTx ? outputs.length + 2 : buttonRequestsCount}
+                    deviceModelInternal={deviceModelInternal}
+                    deviceUnitColor={device?.features?.unit_color}
+                    successText={<Translation id="TR_CONFIRMED_TX" />}
+                    onCancel={onCancel}
+                />
+            }
+        >
+            <TransactionReviewSummary
+                estimateTime={estimateTime}
+                tx={precomposedTx}
+                account={selectedAccount.account}
+                network={selectedAccount.network}
+                broadcast={precomposedForm.options.includes('broadcast')}
+                detailsOpen={detailsOpen}
+                onDetailsClick={() => setDetailsOpen(!detailsOpen)}
+                actionText={actionText}
+            />
+            <TransactionReviewOutputList
+                account={selectedAccount.account}
+                precomposedForm={precomposedForm}
+                precomposedTx={precomposedTx}
+                signedTx={signedTx}
+                decision={decision}
+                detailsOpen={detailsOpen}
+                outputs={outputs}
+                buttonRequestsCount={buttonRequestsCount}
+                isRbfAction={isRbfAction}
+                actionText={actionText}
+            />
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -5,6 +5,7 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Button, variables } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { TranslationKey } from '@suite-common/intl-types';
 import { copyToClipboard, download } from '@trezor/dom-utils';
 import { useDispatch } from 'src/hooks/suite';
 import { TransactionReviewDetails } from './TransactionReviewDetails';
@@ -18,6 +19,7 @@ import type {
 import { getOutputState } from 'src/utils/wallet/reviewTransactionUtils';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
 import { ReviewOutput } from 'src/types/wallet/transaction';
+import { StakeFormState } from '@suite-common/wallet-types';
 
 const Content = styled.div`
     display: flex;
@@ -73,7 +75,7 @@ const StyledButton = styled(Button)`
 
 export interface TransactionReviewOutputListProps {
     account: Account;
-    precomposedForm: FormState;
+    precomposedForm: FormState | StakeFormState;
     precomposedTx: PrecomposedTransactionFinal | TxFinalCardano;
     signedTx?: { tx: string }; // send reducer
     decision?: { resolve: (success: boolean) => void }; // dfd
@@ -81,6 +83,7 @@ export interface TransactionReviewOutputListProps {
     outputs: ReviewOutput[];
     buttonRequestsCount: number;
     isRbfAction: boolean;
+    actionText: TranslationKey;
 }
 
 export const TransactionReviewOutputList = ({
@@ -93,13 +96,21 @@ export const TransactionReviewOutputList = ({
     outputs,
     buttonRequestsCount,
     isRbfAction,
+    actionText,
 }: TransactionReviewOutputListProps) => {
     const dispatch = useDispatch();
     const { networkType } = account;
 
     const { symbol } = account;
-    const { options, selectedFee, isCoinControlEnabled, hasCoinControlBeenOpened } =
-        precomposedForm;
+    const { options, selectedFee } = precomposedForm;
+    let isCoinControlEnabled = false;
+    let hasCoinControlBeenOpened = false;
+    if ('isCoinControlEnabled' in precomposedForm) {
+        ({ isCoinControlEnabled } = precomposedForm);
+    }
+    if ('hasCoinControlBeenOpened' in precomposedForm) {
+        ({ hasCoinControlBeenOpened } = precomposedForm);
+    }
     const broadcastEnabled = options.includes('broadcast');
 
     const reportTransactionCreatedEvent = (action: 'sent' | 'copied' | 'downloaded' | 'replaced') =>
@@ -204,7 +215,7 @@ export const TransactionReviewOutputList = ({
                             isDisabled={!signedTx}
                             onClick={handleSend}
                         >
-                            <Translation id={isRbfAction ? 'TR_REPLACE_TX' : 'SEND_TRANSACTION'} />
+                            <Translation id={actionText} />
                         </StyledButton>
                     ) : (
                         <>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -31,7 +31,7 @@ const StepIndicator = ({ signedTx, outputs, buttonRequestsCount }: StepIndicator
 
 type TransactionReviewTotalOutputProps = Omit<
     TransactionReviewOutputListProps,
-    'precomposedForm' | 'decision' | 'detailsOpen' | 'isRbfAction'
+    'precomposedForm' | 'decision' | 'detailsOpen' | 'isRbfAction' | 'actionText'
 >;
 
 const getLines = (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
 import { transparentize, darken } from 'polished';
 import { getFeeUnits, formatNetworkAmount, formatAmount } from '@suite-common/wallet-utils';
+import { TranslationKey } from '@suite-common/intl-types';
 import { Icon, useTheme, CoinLogo, variables } from '@trezor/components';
 import { Translation, FormattedCryptoAmount, AccountLabel } from 'src/components/suite';
 import { Account, Network } from 'src/types/wallet';
@@ -199,8 +200,8 @@ interface TransactionReviewSummaryProps {
     network: Network;
     broadcast?: boolean;
     detailsOpen: boolean;
-    isRbfAction?: boolean;
     onDetailsClick: () => void;
+    actionText: TranslationKey;
 }
 
 export const TransactionReviewSummary = ({
@@ -210,8 +211,8 @@ export const TransactionReviewSummary = ({
     network,
     broadcast,
     detailsOpen,
-    isRbfAction,
     onDetailsClick,
+    actionText,
 }: TransactionReviewSummaryProps) => {
     const drafts = useSelector(state => state.wallet.send.drafts);
     const currentAccountKey = useSelector(
@@ -241,7 +242,7 @@ export const TransactionReviewSummary = ({
                     </NestedIconWrapper>
                 </IconWrapper>
                 <Headline>
-                    <Translation id={isRbfAction ? 'TR_REPLACE_TX' : 'SEND_TRANSACTION'} />
+                    <Translation id={actionText} />
                     <HeadlineAmount>
                         <FormattedCryptoAmount
                             disableHiddenPlaceholder

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/ConfirmStakeEthModal.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Button, Checkbox, H2, Icon, useTheme, variables } from '@trezor/components';
+import { Modal, Translation, TrezorLink } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
+
+const StyledModal = styled(Modal)`
+    width: 500px;
+    text-align: left;
+`;
+
+const VStack = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-top: 26px;
+`;
+
+const Flex = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const Divider = styled.div`
+    height: 1px;
+    background: ${({ theme }) => theme.STROKE_GREY};
+    margin: 20px 0 17px auto;
+    max-width: 396px;
+    width: 100%;
+
+    ${variables.SCREEN_QUERY.BELOW_TABLET} {
+        max-width: 428px;
+    }
+`;
+
+const StyledCheckbox = styled(Checkbox)`
+    & > div:nth-child(2) {
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+        font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+        font-size: ${variables.FONT_SIZE.NORMAL};
+    }
+`;
+
+const ButtonsWrapper = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: 100%;
+    margin-top: 20px;
+
+    & > button {
+        font-size: ${variables.FONT_SIZE.NORMAL};
+        padding: 9px 22px;
+        flex: 1 0 164px;
+    }
+`;
+
+interface ConfirmStakeEthModalProps {
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const ConfirmStakeEthModal = ({ onConfirm, onCancel }: ConfirmStakeEthModalProps) => {
+    const theme = useTheme();
+    const dispatch = useDispatch();
+    const [hasAgreed, setHasAgreed] = useState(false);
+
+    const handleOnCancel = () => {
+        onCancel();
+        dispatch(openModal({ type: 'stake' }));
+    };
+
+    const onClick = () => {
+        onConfirm();
+    };
+
+    return (
+        <StyledModal onCancel={handleOnCancel}>
+            <H2>
+                <Translation id="TR_STAKE_CONFIRM_ENTRY_PERIOD" />
+            </H2>
+
+            <VStack>
+                <Flex>
+                    <Icon icon="CLOCK" size={24} color={theme.TYPE_DARK_ORANGE} />
+                    <Translation id="TR_STAKE_ENTERING_POOL_MAY_TAKE" values={{ days: 35 }} />
+                </Flex>
+                <Flex>
+                    <Icon icon="HAND" size={24} color={theme.TYPE_DARK_ORANGE} />
+                    <Translation
+                        id="TR_STAKE_ETH_WILL_BE_BLOCKED"
+                        values={{
+                            a: chunks => (
+                                // TODO: Add the right href
+                                <TrezorLink target="_blank" variant="underline" href="#">
+                                    {chunks}
+                                </TrezorLink>
+                            ),
+                        }}
+                    />
+                </Flex>
+            </VStack>
+
+            <Divider />
+
+            <StyledCheckbox onClick={() => setHasAgreed(!hasAgreed)} isChecked={hasAgreed}>
+                <Translation id="TR_STAKE_ACKNOWLEDGE_ENTRY_PERIOD" />
+            </StyledCheckbox>
+
+            <ButtonsWrapper>
+                <Button variant="tertiary" onClick={handleOnCancel}>
+                    <Translation id="TR_CANCEL" />
+                </Button>
+                <Button isDisabled={!hasAgreed} onClick={onClick}>
+                    <Translation id="TR_STAKE_CONFIRM_AND_STAKE" />
+                </Button>
+            </ButtonsWrapper>
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeModal/StakeEthForm/index.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 import { Button } from '@trezor/components';
+import { isZero } from '@suite-common/wallet-utils';
 import { Translation } from 'src/components/suite';
 import { useStakeEthFormContext } from 'src/hooks/wallet/useStakeEthForm';
 import { AvailableBalance } from '../AvailableBalance';
 import { FormFractionButtons } from 'src/components/suite/FormFractionButtons';
 import { Inputs } from './Inputs';
 import { Fees } from './Fees';
-import { isZero } from '@suite-common/wallet-utils';
+import { ConfirmStakeEthModal } from './ConfirmStakeEthModal';
 
 const Body = styled.div`
     margin-bottom: 26px;
@@ -35,6 +36,9 @@ export const StakeEthForm = () => {
         setMax,
         watch,
         clearForm,
+        isConfirmModalOpen,
+        closeConfirmModal,
+        signTx,
     } = useStakeEthFormContext();
     const { formattedBalance, symbol } = account;
     const hasValues = Boolean(watch('fiatInput') || watch('cryptoInput'));
@@ -43,39 +47,45 @@ export const StakeEthForm = () => {
     const areFractionButtonsDisabled = isZero(account.formattedBalance);
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)}>
-            <Body>
-                <AvailableBalance formattedBalance={formattedBalance} symbol={symbol} />
+        <>
+            {isConfirmModalOpen && (
+                <ConfirmStakeEthModal onConfirm={signTx} onCancel={closeConfirmModal} />
+            )}
 
-                <ButtonsWrapper>
-                    <FormFractionButtons
-                        isDisabled={areFractionButtonsDisabled}
-                        setRatioAmount={setRatioAmount}
-                        setMax={setMax}
-                    />
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <Body>
+                    <AvailableBalance formattedBalance={formattedBalance} symbol={symbol} />
 
-                    {isDirty && (
-                        <Button type="button" variant="tertiary" onClick={clearForm}>
-                            <Translation id="TR_CLEAR_ALL" />
-                        </Button>
-                    )}
-                </ButtonsWrapper>
+                    <ButtonsWrapper>
+                        <FormFractionButtons
+                            isDisabled={areFractionButtonsDisabled}
+                            setRatioAmount={setRatioAmount}
+                            setMax={setMax}
+                        />
 
-                <InputsWrapper>
-                    <Inputs />
-                </InputsWrapper>
+                        {isDirty && (
+                            <Button type="button" variant="tertiary" onClick={clearForm}>
+                                <Translation id="TR_CLEAR_ALL" />
+                            </Button>
+                        )}
+                    </ButtonsWrapper>
 
-                <Fees />
-            </Body>
+                    <InputsWrapper>
+                        <Inputs />
+                    </InputsWrapper>
 
-            <Button
-                fullWidth
-                isDisabled={!(formIsValid && hasValues) || isSubmitting}
-                isLoading={isComposing || isSubmitting}
-                onClick={handleSubmit(onSubmit)}
-            >
-                <Translation id="TR_CONTINUE" />
-            </Button>
-        </form>
+                    <Fees />
+                </Body>
+
+                <Button
+                    fullWidth
+                    isDisabled={!(formIsValid && hasValues) || isSubmitting}
+                    isLoading={isComposing || isSubmitting}
+                    onClick={handleSubmit(onSubmit)}
+                >
+                    <Translation id="TR_CONTINUE" />
+                </Button>
+            </form>
+        </>
     );
 };

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { FieldPath, UseFormReturn } from 'react-hook-form';
+
+import { FeeLevel } from '@trezor/connect';
+import { useAsyncDebounce } from '@trezor/react-utils';
+import { useDispatch, useTranslation } from 'src/hooks/suite';
+import { composeTransaction } from 'src/actions/wallet/stakeActions';
+import { findComposeErrors } from '@suite-common/wallet-utils';
+import {
+    StakeFormState,
+    StakeContextValues,
+    ComposeActionContext,
+    PrecomposedTransaction,
+    PrecomposedLevels,
+} from '@suite-common/wallet-types';
+import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
+
+const DEFAULT_FIELD = 'outputs.0.amount';
+
+interface Props<TFieldValues extends StakeFormState> extends UseFormReturn<TFieldValues> {
+    state?: ComposeActionContext;
+    defaultField?: FieldPath<TFieldValues>;
+}
+
+export const useStakeCompose = <TFieldValues extends StakeFormState>({
+    state,
+    defaultField,
+    getValues,
+    formState: { errors },
+    clearErrors,
+    ...props
+}: Props<TFieldValues>) => {
+    const [isLoading, setLoading] = useState(false);
+    const composeRequestIDRef = useRef(0);
+    const defaultFieldRef = useRef(defaultField || DEFAULT_FIELD);
+    const [composedLevels, setComposedLevels] =
+        useState<StakeContextValues['composedLevels']>(undefined);
+    const [composeField, setComposeField] = useState<string | undefined>(undefined);
+    const { translationString } = useTranslation();
+
+    const dispatch = useDispatch();
+
+    // actions
+    const debounce = useAsyncDebounce();
+
+    // Type assertion allowing to make the hook reusable, see https://stackoverflow.com/a/73624072
+    // This allows the hook to set values and errors for fields shared among multiple forms without passing them as arguments.
+    const { setError, setValue } = props as unknown as UseFormReturn<StakeFormState>;
+
+    // update composeRequestID
+    const composeRequest = useCallback(
+        async (field = defaultFieldRef.current) => {
+            if (!state) return;
+            // reset precomposed transactions
+            setComposedLevels(undefined);
+            // set ref for later use in useEffect
+            composeRequestIDRef.current += 1;
+            // clear errors from previous compose process
+            const composeErrors = findComposeErrors(errors);
+            if (composeErrors.length > 0) {
+                clearErrors(composeErrors);
+            }
+            // set field value for later use in updateComposedValues
+            setComposeField(field);
+            // start composing
+            setLoading(true);
+
+            // store current request ID before async debounced process and compare it later. see explanation below
+            const resultID = composeRequestIDRef.current;
+            const result = await debounce(() => {
+                if (Object.keys(errors).length > 0) {
+                    return Promise.resolve(undefined);
+                }
+
+                const values = getValues();
+                return dispatch(composeTransaction(values, state));
+            });
+
+            // RACE-CONDITION NOTE:
+            // resultID could be outdated when composeRequestID was updated by another upcoming/pending composeRequest and render tick didn't process it yet,
+            // therefore another debounce process was not called yet to interrupt current one
+            // unexpected result: `updateComposedValues` is trying to work with updated/newer FormState
+            if (resultID === composeRequestIDRef.current) {
+                if (result) {
+                    // set new composed transactions
+                    setComposedLevels(result);
+                } else {
+                    // result undefined: (FormState got errors or sendFormActions got errors)
+                    // undefined result will not be processed by useEffect below, reset loader
+                    setLoading(false);
+                }
+            }
+        },
+        [state, errors, debounce, clearErrors, getValues, dispatch],
+    );
+
+    // update fields AFTER composedLevels change or selectedFee change (below)
+    const updateComposedValues = useCallback(
+        (composed: PrecomposedTransaction) => {
+            const values = getValues();
+            if (composed.type === 'error') {
+                const { error, errorMessage } = composed;
+                if (!errorMessage) {
+                    // composed tx doesn't have an errorMessage (Translation props)
+                    // this error is unexpected and should be handled in sendFormActions
+                    console.warn('Compose unexpected error', error);
+                    setLoading(false);
+                    return;
+                }
+
+                const formError = {
+                    type: COMPOSE_ERROR_TYPES.COMPOSE,
+                    message: translationString(errorMessage.id, errorMessage.values),
+                };
+
+                if (composeField) {
+                    // setError to the field which created `composeRequest`
+                    setError(composeField as FieldPath<StakeFormState>, formError);
+                } else if (defaultFieldRef.current !== DEFAULT_FIELD) {
+                    // if defaultField in not an amount (like rbf case, defaultField: selectedFee)
+                    // setError to this particular field
+                    setError(defaultFieldRef.current as FieldPath<StakeFormState>, formError);
+                } else if (values.outputs) {
+                    // setError to the all `Amount` fields, composeField is not specified (load draft case)
+                    values.outputs.forEach((_, i) => setError(`outputs.${i}.amount`, formError));
+                }
+                setLoading(false);
+                return;
+            }
+
+            const composeErrors = findComposeErrors(errors);
+            if (composeErrors.length > 0) {
+                clearErrors(composeErrors);
+            }
+
+            // update feeLimit field if present (calculated from ethereum data size)
+            setValue('estimatedFeeLimit', composed.estimatedFeeLimit);
+            setLoading(false);
+        },
+        [composeField, getValues, setValue, errors, setError, clearErrors, translationString],
+    );
+
+    // called from the useFees sub-hook
+    const onFeeLevelChange = useCallback(
+        (prev: StakeFormState['selectedFee'], current: StakeFormState['selectedFee']) => {
+            if (!composedLevels) return;
+            if (current === 'custom') {
+                // set custom level from previously selected level
+                const prevLevel = composedLevels[prev || 'normal'];
+                const levels = {
+                    ...composedLevels,
+                    custom: prevLevel,
+                } as PrecomposedLevels & { custom: PrecomposedTransaction };
+                setComposedLevels(levels);
+            } else {
+                const currentLevel = composedLevels[current || 'normal'];
+                updateComposedValues(currentLevel);
+            }
+        },
+        [composedLevels, updateComposedValues],
+    );
+
+    const switchToNearestFee = useCallback(
+        (composedLevels: NonNullable<StakeContextValues['composedLevels']>) => {
+            const { selectedFee, setMaxOutputId } = getValues();
+            let composed = composedLevels[selectedFee || 'normal'];
+
+            // selectedFee was not set yet (no interaction with Fees) and default (normal) fee tx is not valid
+            // OR setMax option was used
+            // try to switch to nearest possible composed transaction
+            const shouldSwitch =
+                !selectedFee || (typeof setMaxOutputId === 'number' && selectedFee !== 'custom');
+            if (shouldSwitch && composed.type === 'error') {
+                // find nearest possible tx
+                const nearest = Object.keys(composedLevels)
+                    .reverse()
+                    .find((key): key is FeeLevel['label'] => composedLevels[key].type !== 'error');
+                // switch to it
+                if (nearest) {
+                    composed = composedLevels[nearest];
+                    setValue('selectedFee', nearest);
+                    if (nearest === 'custom') {
+                        // @ts-expect-error: type = error already filtered above
+                        const { feePerByte, feeLimit } = composed;
+                        setValue('feePerUnit', feePerByte);
+                        setValue('feeLimit', feeLimit || '');
+                    }
+                }
+                // or do nothing, use default composed tx
+            }
+
+            // composed transaction does not exists (should never happen)
+            if (!composed) return;
+
+            updateComposedValues(composed);
+        },
+        [getValues, setValue, updateComposedValues],
+    );
+
+    // trigger initial compose process
+    useEffect(() => {
+        if (state && composeRequestIDRef.current === 0) {
+            composeRequest();
+        }
+    }, [state, composeRequest]);
+
+    // handle composedLevels change
+    useEffect(() => {
+        // do nothing if there are no composedLevels
+        if (!composedLevels) return;
+        switchToNearestFee(composedLevels);
+    }, [composedLevels, switchToNearestFee]);
+
+    return {
+        isLoading,
+        composeRequest,
+        composedLevels,
+        onFeeLevelChange,
+    };
+};

--- a/packages/suite/src/hooks/wallet/useStakeEthFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useStakeEthFormDefaultValues.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
-import { StakeEthFormState } from 'src/types/wallet/stakeEthForm';
+import { StakeFormState } from '@suite-common/wallet-types';
 
 export const useStakeEthFormDefaultValues = (defaultAddress?: string) => {
     const defaultValues = useMemo(
@@ -17,7 +17,8 @@ export const useStakeEthFormDefaultValues = (defaultAddress?: string) => {
                     },
                 ],
                 options: ['broadcast'],
-            }) as StakeEthFormState,
+                ethereumStakeType: 'stake',
+            }) as StakeFormState,
         [defaultAddress],
     );
 

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -46,7 +46,7 @@ const buttonRequest =
                 router: { route },
             } = api.getState();
             if (account?.networkType === 'cardano' || account?.networkType === 'ethereum') {
-                if (route?.name === 'wallet-send') {
+                if (route?.name === 'wallet-send' || route?.name === 'wallet-staking') {
                     api.dispatch({
                         ...action,
                         payload: { ...action.payload, code: 'ButtonRequest_SignTx' },

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -9,6 +9,7 @@ import {
     transactionsActions,
     unsubscribeBlockchainThunk,
     deviceActions,
+    stakeActions,
 } from '@suite-common/wallet-core';
 import { settingsCommonConfig } from '@suite-common/suite-config';
 
@@ -110,6 +111,7 @@ const walletMiddleware =
             api.dispatch(sendFormActions.dispose());
             api.dispatch(receiveActions.dispose());
             api.dispatch(coinmarketBuyActions.dispose());
+            api.dispatch(stakeActions.dispose());
         }
 
         if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -6,6 +6,7 @@ import {
     prepareTransactionsReducer,
     prepareBlockchainReducer,
     prepareDiscoveryReducer,
+    prepareStakeReducer,
 } from '@suite-common/wallet-core';
 
 import { extraDependencies } from 'src/support/extraDependencies';
@@ -28,6 +29,7 @@ export const accountsReducer = prepareAccountsReducer(extraDependencies);
 export const blockchainReducer = prepareBlockchainReducer(extraDependencies);
 export const fiatRatesReducer = prepareFiatRatesReducer(extraDependencies);
 export const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
+export const stakeReducer = prepareStakeReducer(extraDependencies);
 
 const WalletReducers = combineReducers({
     fiat: fiatRatesReducer,
@@ -47,6 +49,7 @@ const WalletReducers = combineReducers({
     cardanoStaking: cardanoStakingReducer,
     pollings: pollingReducer,
     coinjoin: coinjoinReducer,
+    stake: stakeReducer,
 });
 
 export default WalletReducers;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -8465,4 +8465,37 @@ export default defineMessages({
         defaultMessage:
             'We recommend you to leave {amount} ETH so you will be able to pay for withdrawal fees',
     },
+    TR_STAKE_CONFIRM_ENTRY_PERIOD: {
+        id: 'TR_STAKE_CONFIRM_ENTRY_PERIOD',
+        defaultMessage: 'Confirm entry period',
+    },
+    TR_STAKE_CONFIRM_AND_STAKE: {
+        id: 'TR_STAKE_CONFIRM_AND_STAKE',
+        defaultMessage: 'Confirm & stake',
+    },
+    TR_STAKE_ENTERING_POOL_MAY_TAKE: {
+        id: 'TR_STAKE_ENTERING_POOL_MAY_TAKE',
+        defaultMessage: 'Entering the staking pool may take up to {days} days',
+    },
+    TR_STAKE_ETH_WILL_BE_BLOCKED: {
+        id: 'TR_STAKE_ETH_WILL_BE_BLOCKED',
+        defaultMessage:
+            'Your ETH will be blocked during this period, and you can’t cancel this. <a>Learn more</a>',
+    },
+    TR_STAKE_ACKNOWLEDGE_ENTRY_PERIOD: {
+        id: 'TR_STAKE_ACKNOWLEDGE_ENTRY_PERIOD',
+        defaultMessage: 'I acknowledge the above entry period',
+    },
+    TR_STAKE_STAKE: {
+        id: 'TR_STAKE_STAKE',
+        defaultMessage: 'Stake',
+    },
+    TR_STAKE_UNSTAKE: {
+        id: 'TR_STAKE_UNSTAKE',
+        defaultMessage: 'Unstake',
+    },
+    TR_STAKE_CLAIM: {
+        id: 'TR_STAKE_CLAIM',
+        defaultMessage: 'Claim',
+    },
 });

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -3,6 +3,7 @@ import {
     accountsActions,
     fiatRatesActions,
     blockchainActions,
+    stakeActions,
 } from '@suite-common/wallet-core';
 import { ArrayElement } from '@trezor/type-utils';
 
@@ -62,6 +63,7 @@ type AccountsAction = ReturnType<(typeof accountsActions)[keyof typeof accountsA
 type FiatRatesAction = ReturnType<(typeof fiatRatesActions)[keyof typeof fiatRatesActions]>;
 type BlockchainAction = ReturnType<(typeof blockchainActions)[keyof typeof blockchainActions]>;
 type DiscoveryAction = ReturnType<(typeof discoveryActions)[keyof typeof discoveryActions]>;
+type StakeAction = ReturnType<(typeof stakeActions)[keyof typeof stakeActions]>;
 
 export type WalletAction =
     | BlockchainAction
@@ -84,4 +86,5 @@ export type WalletAction =
     | PollingAction
     | CoinjoinAccountAction
     | CoinjoinClientAction
-    | AccountsAction;
+    | AccountsAction
+    | StakeAction;

--- a/packages/suite/src/types/wallet/stakeEthForm.ts
+++ b/packages/suite/src/types/wallet/stakeEthForm.ts
@@ -1,47 +1,7 @@
-import { UseFormReturn } from 'react-hook-form';
-import {
-    Account,
-    FormState,
-    PrecomposedLevels,
-    PrecomposedLevelsCardano,
-} from '@suite-common/wallet-types';
-import { Network } from './index';
-import { FormState as ReactHookFormState } from 'react-hook-form/dist/types/form';
-import { AmountLimits } from './coinmarketCommonTypes';
-import { FiatCurrencyCode } from '@suite-common/suite-config';
 import { WithSelectedAccountLoadedProps } from '../../components/wallet';
-import { FeeLevel } from '@trezor/connect';
 
 export const FIAT_INPUT = 'fiatInput';
 export const CRYPTO_INPUT = 'cryptoInput';
 export const OUTPUT_AMOUNT = 'outputs.0.amount';
 
 export type UseStakeEthFormProps = WithSelectedAccountLoadedProps;
-
-export interface StakeEthFormState extends FormState {
-    fiatInput?: string;
-    cryptoInput?: string;
-}
-
-export type StakeEthContextValues = UseFormReturn<StakeEthFormState> & {
-    onSubmit: () => void;
-    account: Account;
-    network: Network;
-    cryptoInputValue?: string;
-    removeDraft: (key: string) => void;
-    formState: ReactHookFormState<StakeEthFormState>;
-    isDraft: boolean;
-    amountLimits: AmountLimits;
-    onCryptoAmountChange: (amount: string) => void;
-    onFiatAmountChange: (amount: string) => void;
-    localCurrency: FiatCurrencyCode;
-    composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
-    isComposing: boolean;
-    setMax: () => void;
-    setRatioAmount: (divisor: number) => void;
-    isAmountForWithdrawalWarningShown: boolean;
-    isAdviceForWithdrawalWarningShown: boolean;
-    // TODO: Implement fee switcher
-    selectedFee: FeeLevel['label'];
-    clearForm: () => void;
-};

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -1,0 +1,28 @@
+import { TranslationKey } from '@suite-common/intl-types';
+import { StakeFormState } from '@suite-common/wallet-types';
+
+interface getTransactionReviewModalActionTextParams {
+    ethereumStakeType: StakeFormState['ethereumStakeType'] | null;
+    isRbfAction: boolean;
+}
+
+export const getTransactionReviewModalActionText = ({
+    ethereumStakeType,
+    isRbfAction,
+}: getTransactionReviewModalActionTextParams): TranslationKey => {
+    switch (ethereumStakeType) {
+        case 'stake':
+            return 'TR_STAKE_STAKE';
+        case 'unstake':
+            return 'TR_STAKE_UNSTAKE';
+        case 'claim':
+            return 'TR_STAKE_CLAIM';
+        // no default
+    }
+
+    if (isRbfAction) {
+        return 'TR_REPLACE_TX';
+    }
+
+    return 'SEND_TRANSACTION';
+};

--- a/packages/suite/src/utils/wallet/reviewTransactionUtils.ts
+++ b/packages/suite/src/utils/wallet/reviewTransactionUtils.ts
@@ -8,6 +8,7 @@ import { FormState, PrecomposedTransactionFinal, TxFinalCardano } from 'src/type
 import { Account } from 'src/types/wallet/index';
 import { getShortFingerprint, isCardanoTx } from '@suite-common/wallet-utils';
 import { ReviewOutput } from 'src/types/wallet/transaction';
+import { StakeFormState } from '@suite-common/wallet-types';
 
 export const getOutputState = (index: number, buttonRequestsCount: number) => {
     if (index === buttonRequestsCount - 1) return 'active';
@@ -73,7 +74,7 @@ type ConstructOutputsParams = {
     precomposedTx: TxFinalCardano | PrecomposedTransactionFinal;
     decreaseOutputId: number | undefined;
     account: Account;
-    precomposedForm: FormState;
+    precomposedForm: FormState | StakeFormState;
 };
 
 const constructOldFlow = ({
@@ -86,6 +87,9 @@ const constructOldFlow = ({
 
     const isCardano = isCardanoTx(account, precomposedTx);
     const { networkType } = account;
+
+    const hasBitcoinLockTime = 'bitcoinLockTime' in precomposedForm;
+    const hasRippleDestinationTag = 'rippleDestinationTag' in precomposedForm;
 
     // used in the bumb fee flow
     if (typeof precomposedTx.useNativeRbf === 'boolean' && precomposedTx.useNativeRbf) {
@@ -149,7 +153,7 @@ const constructOldFlow = ({
         });
     }
 
-    if (precomposedForm.bitcoinLockTime) {
+    if (hasBitcoinLockTime && precomposedForm.bitcoinLockTime) {
         outputs.push({ type: 'locktime', value: precomposedForm.bitcoinLockTime });
     }
 
@@ -163,7 +167,7 @@ const constructOldFlow = ({
         // 2. fee
         // 3. output
         outputs.unshift({ type: 'fee', value: precomposedTx.fee });
-        if (precomposedForm.rippleDestinationTag) {
+        if (hasRippleDestinationTag && precomposedForm.rippleDestinationTag) {
             outputs.unshift({
                 type: 'destination-tag',
                 value: precomposedForm.rippleDestinationTag,
@@ -188,6 +192,9 @@ const constructNewFlow = ({
     const isCardano = isCardanoTx(account, precomposedTx);
     const isSolana = account.networkType === 'solana';
     const { networkType } = account;
+
+    const hasBitcoinLockTime = 'bitcoinLockTime' in precomposedForm;
+    const hasRippleDestinationTag = 'rippleDestinationTag' in precomposedForm;
 
     // used in the bumb fee flow
     if (typeof precomposedTx.useNativeRbf === 'boolean' && precomposedTx.useNativeRbf) {
@@ -281,7 +288,7 @@ const constructNewFlow = ({
         });
     }
 
-    if (precomposedForm.bitcoinLockTime) {
+    if (hasBitcoinLockTime && precomposedForm.bitcoinLockTime) {
         outputs.push({ type: 'locktime', value: precomposedForm.bitcoinLockTime });
     }
 
@@ -289,7 +296,11 @@ const constructNewFlow = ({
         outputs.push({ type: 'data', value: precomposedForm.ethereumDataHex });
     }
 
-    if (networkType === 'ripple' && precomposedForm.rippleDestinationTag) {
+    if (
+        networkType === 'ripple' &&
+        hasRippleDestinationTag &&
+        precomposedForm.rippleDestinationTag
+    ) {
         outputs.unshift({
             type: 'destination-tag',
             value: precomposedForm.rippleDestinationTag,

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -357,7 +357,7 @@ export const networks = {
             address: 'https://goerli1.trezor.io/address/',
             queryString: '',
         },
-        features: ['rbf', 'sign-verify', 'tokens'],
+        features: ['rbf', 'sign-verify', 'tokens', 'staking'],
         customBackends: ['blockbook'],
         accountTypes: {},
     },

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -22,3 +22,5 @@ export * from './device/deviceActions';
 export * from './device/deviceThunks';
 export * from './device/deviceReducer';
 export * from './device/deviceConstants';
+export * from './stake/stakeActions';
+export * from './stake/stakeReducer';

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import { Account, StakeFormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+
+export const STAKE_MODULE_PREFIX = '@common/wallet-core/stake';
+
+type RequestSignTransactionPayload = {
+    formValues: StakeFormState;
+    transactionInfo: PrecomposedTransactionFinal;
+};
+
+type RequestPushTransactionPayload = {
+    tx: string;
+    coin: Account['symbol'];
+};
+
+const requestSignTransaction = createAction(
+    `${STAKE_MODULE_PREFIX}/requestSignTransaction`,
+    (payload?: RequestSignTransactionPayload) => ({
+        payload,
+    }),
+);
+
+const requestPushTransaction = createAction(
+    `${STAKE_MODULE_PREFIX}/requestPushTransaction`,
+    (payload?: RequestPushTransactionPayload) => ({
+        payload,
+    }),
+);
+
+const dispose = createAction(`${STAKE_MODULE_PREFIX}/dispose`);
+
+export const stakeActions = {
+    requestSignTransaction,
+    requestPushTransaction,
+    dispose,
+};

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -1,0 +1,53 @@
+import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { StakeFormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { cloneObject } from '@trezor/utils';
+
+import { stakeActions } from './stakeActions';
+
+export interface StakeState {
+    precomposedTx?: PrecomposedTransactionFinal;
+    precomposedForm?: StakeFormState;
+    signedTx?: { tx: string; coin: string }; // payload for TrezorConnect.pushTransaction
+}
+
+export const stakeInitialState: StakeState = {
+    precomposedTx: undefined,
+    signedTx: undefined,
+};
+
+export type StakeRootState = {
+    wallet: {
+        stake: StakeState;
+    };
+};
+
+export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState, builder => {
+    builder
+        .addCase(stakeActions.requestSignTransaction, (state, action) => {
+            if (action.payload) {
+                state.precomposedTx = action.payload.transactionInfo;
+                // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
+                // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
+                // TypeError: Cannot assign to read only property of object '#<Object>'
+                // This might not be necessary in the future when the dependencies are upgraded.
+                state.precomposedForm = cloneObject(action.payload.formValues);
+            } else {
+                delete state.precomposedTx;
+                delete state.precomposedForm;
+            }
+        })
+        .addCase(stakeActions.requestPushTransaction, (state, action) => {
+            if (action.payload) {
+                state.signedTx = action.payload;
+            } else {
+                delete state.signedTx;
+            }
+        })
+        .addCase(stakeActions.dispose, state => {
+            delete state.precomposedTx;
+            delete state.precomposedForm;
+            delete state.signedTx;
+        });
+});
+
+export const selectStake = (state: StakeRootState) => state.wallet.stake;

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -9,3 +9,4 @@ export * from './sendForm';
 export * from './settings';
 export * from './selectedAccount';
 export * from './transaction';
+export * from './stakeForm';

--- a/suite-common/wallet-types/src/stakeForm.ts
+++ b/suite-common/wallet-types/src/stakeForm.ts
@@ -1,0 +1,57 @@
+import { UseFormReturn } from 'react-hook-form';
+
+import { FormState as ReactHookFormState } from 'react-hook-form/dist/types/form';
+
+import { FeeLevel } from '@trezor/connect';
+import { Network } from '@trezor/suite/src/types/wallet';
+import { AmountLimits } from '@trezor/suite/src/types/wallet/coinmarketCommonTypes';
+import { FiatCurrencyCode } from '@suite-common/suite-config';
+
+import { Output, PrecomposedLevels, RbfTransactionParams } from './transaction';
+import { FormOptions } from './sendForm';
+import { Account } from './account';
+
+export interface StakeFormState {
+    fiatInput?: string;
+    cryptoInput?: string;
+    setMaxOutputId?: number;
+    outputs: Output[]; // output arrays, each element is corresponding with single Output item
+    estimatedFeeLimit?: string; // ethereum only (gasLimit)
+    feePerUnit: string; // bitcoin/ethereum/ripple custom fee field (satB/gasPrice/drops)
+    feeLimit: string; // ethereum only (gasLimit)
+    selectedFee?: FeeLevel['label'];
+    rbfParams?: RbfTransactionParams;
+    ethereumDataHex?: string;
+    ethereumNonce?: string; // TODO: ethereum RBF
+    ethereumDataAscii?: string;
+    ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
+    ethereumStakeType?: 'stake' | 'unstake' | 'claim';
+    options: FormOptions[];
+    anonymityWarningChecked?: boolean;
+}
+
+export type StakeContextValues = UseFormReturn<StakeFormState> & {
+    onSubmit: () => void;
+    account: Account;
+    network: Network;
+    cryptoInputValue?: string;
+    removeDraft: (key: string) => void;
+    formState: ReactHookFormState<StakeFormState>;
+    isDraft: boolean;
+    amountLimits: AmountLimits;
+    onCryptoAmountChange: (amount: string) => void;
+    onFiatAmountChange: (amount: string) => void;
+    localCurrency: FiatCurrencyCode;
+    composedLevels?: PrecomposedLevels;
+    isComposing: boolean;
+    setMax: () => void;
+    setRatioAmount: (divisor: number) => void;
+    isAmountForWithdrawalWarningShown: boolean;
+    isAdviceForWithdrawalWarningShown: boolean;
+    // TODO: Implement fee switcher
+    selectedFee: FeeLevel['label'];
+    clearForm: () => void;
+    isConfirmModalOpen: boolean;
+    closeConfirmModal: () => void;
+    signTx: () => Promise<void>;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The "Confirm Entry Period" and "Sign Tx" modal layouts are added to the ETH staking flow.

The PR also has some Redux logic for staking. NB! There are 2 `stakeActions` files. One inside `suite-common/wallet-core/src/stake` and another one in `suite/src/actions/wallet`. Ideally, the second one should be moved to thunks in `wallet-core` but it will require some other actions, which this file depends on e.g. `modalActions` and `metadataActions` to be moved to `wallet-core` as well. For now, it exists to be consistent with `sendFormActions`. This consisitency is useful for `TransactionReviewModal`

P.S. Do not execute txs, there is send logic under the hood there for now. It will be replaced when the work on staking SDK integration starts

## Related Issue

Resolve <!--- link the issue here -->
https://github.com/trezor/trezor-suite/issues/9267

## Screenshots:
<img width="760" alt="Знімок екрана 2023-12-11 о 15 34 18" src="https://github.com/everstake/trezor-suite/assets/42133844/508dfca7-0edd-4ace-a31c-69f611128d2c">
<img width="760" alt="Знімок екрана 2023-12-11 о 15 34 55" src="https://github.com/everstake/trezor-suite/assets/42133844/62f693b2-3288-4f08-9535-51ee7fb228fb">

