### PR TITLE
feat(suite-native): cardano staking migration nudge

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -124,7 +124,9 @@ export const AccountsListItem = ({
                     {formattedAccountType && (
                         <Badge label={formattedAccountType} size="small" elevation="1" />
                     )}
-                    {shouldShowStakingBadge && <StakingBadge />}
+                    {shouldShowStakingBadge && (
+                        <StakingBadge networkSymbol={account.symbol} account={account} />
+                    )}
                     {shouldShowTokenBadge && <TokenBadge accountKey={account.key} />}
                 </>
             }

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
@@ -7,6 +7,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 export type AccountListItemBaseProps = {
     icon: React.ReactNode;
     title: React.ReactNode;
+    secondaryTitle?: React.ReactNode;
     mainValue: React.ReactNode;
     secondaryValue: React.ReactNode;
     badges?: React.ReactNode;
@@ -85,6 +86,7 @@ const valuesContainerStyle = prepareNativeStyle(utils => ({
 export const AccountsListItemBase = ({
     icon,
     title,
+    secondaryTitle,
     badges,
     mainValue,
     secondaryValue,
@@ -114,6 +116,7 @@ export const AccountsListItemBase = ({
                 <Box marginRight="sp16">{icon}</Box>
                 <Box style={applyStyle(accountDescriptionStyle)}>
                     <Text>{title}</Text>
+                    {secondaryTitle}
                     <HStack spacing="sp4" alignItems="center">
                         {badges}
                     </HStack>

--- a/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
@@ -1,12 +1,16 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
-import { RoundedIcon } from '@suite-native/atoms';
+import { RoundedIcon, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { NativeStakingRootState } from '@suite-native/staking';
-import { selectIsCardanoStakedOutsideEverstake } from '@suite-native/staking/src/cardanoStakingSelectors';
+import {
+    selectIsCardanoStakedOutsideEverstake,
+    selectIsCardanoStakedWithFiveBinaries,
+} from '@suite-native/staking/src/cardanoStakingSelectors';
 import { useNativeStyles } from '@trezor/styles';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
@@ -32,6 +36,9 @@ export const AdaAccountsListStakingItem = ({
     const isStakedOutsideEverstake = useSelector((state: NativeStakingRootState) =>
         selectIsCardanoStakedOutsideEverstake(state, account.key),
     );
+    const isStakedWithFiveBinaries = useSelector((state: AccountsRootState) =>
+        selectIsCardanoStakedWithFiveBinaries(state, account.key),
+    );
 
     const icon = useMemo(
         () =>
@@ -56,6 +63,13 @@ export const AdaAccountsListStakingItem = ({
                 />
             }
             title={<Translation id="accountList.staking" />}
+            secondaryTitle={
+                isStakedWithFiveBinaries && (
+                    <Text variant="hint" color="textAlertYellow">
+                        <Translation id="accountList.rewardsReduced" />
+                    </Text>
+                )
+            }
             mainValue={icon}
             secondaryValue={undefined}
         />

--- a/suite-native/accounts/src/components/AccountsList/StakingBadge.tsx
+++ b/suite-native/accounts/src/components/AccountsList/StakingBadge.tsx
@@ -1,11 +1,56 @@
-import { RoundedIcon, RoundedIconProps } from '@suite-native/atoms';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
-export const StakingBadge = (props: Partial<RoundedIconProps>) => (
-    <RoundedIcon
-        name="piggyBank"
-        color="textSubdued"
-        iconSize="small"
-        containerSize={22}
-        {...props}
-    />
-);
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
+import { CompoundRoundedIcon } from '@suite-native/atoms';
+import { IconName, IconSize } from '@suite-native/icons';
+import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { Color } from '@trezor/theme';
+
+type CompoundIcon = {
+    name: IconName;
+    color?: Color;
+    size?: IconSize;
+};
+
+const BASE_ICON: CompoundIcon = {
+    name: 'piggyBank',
+    color: 'textSubdued',
+    size: 'small',
+};
+
+const WARNING_ICON: CompoundIcon = {
+    name: 'warning',
+    color: 'iconAlertYellow',
+    size: 'small',
+};
+
+type StakingBadgeProps = {
+    networkSymbol: NetworkSymbol;
+    account?: Account;
+};
+
+export const StakingBadge = ({ networkSymbol, account }: StakingBadgeProps) => {
+    const firstAccountStakedWithFiveBinaries = useSelector(
+        (state: AccountsRootState & DeviceRootState) =>
+            selectFirstCardanoAccountStakedWithFiveBinaries(state),
+    );
+
+    const shouldShowWarningIcon = useMemo(() => {
+        if (networkSymbol !== 'ada') return false;
+
+        if (account) return isCardanoStakedWithFiveBinaries(account);
+
+        return !!firstAccountStakedWithFiveBinaries;
+    }, [firstAccountStakedWithFiveBinaries, networkSymbol, account]);
+
+    const compoundIcons = useMemo<CompoundIcon[]>(
+        () => [BASE_ICON, ...(shouldShowWarningIcon ? [WARNING_ICON] : [])],
+        [shouldShowWarningIcon],
+    );
+
+    return <CompoundRoundedIcon containerSize={22} compoundIcons={compoundIcons} />;
+};

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -128,7 +128,9 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol, onPress }: AssetIte
                     <Text variant="hint" color="textSubdued">
                         {accountsPerAsset}
                     </Text>
-                    {hasAnyAccountsWithStaking && <StakingBadge />}
+                    {hasAnyAccountsWithStaking && (
+                        <StakingBadge networkSymbol={cryptoCurrencySymbol} />
+                    )}
                     {hasAnyTokens && (
                         <Badge
                             elevation="1"

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -10,6 +10,7 @@ import { selectHasRunningDiscovery, selectIsDeviceAuthorized } from '@suite-comm
 import { OnSelectAccount } from '@suite-native/accounts';
 import { AnimatedCard } from '@suite-native/atoms';
 import { AccountsRediscoveryNeededWarning } from '@suite-native/discovery';
+import { FiveBinariesHomeBanner } from '@suite-native/module-staking-management';
 import {
     AppTabsParamList,
     AppTabsRoutes,
@@ -64,6 +65,7 @@ export const Assets = () => {
 
     return (
         <>
+            <FiveBinariesHomeBanner />
             <AnimatedCard noPadding layout={LinearTransition}>
                 <AccountsRediscoveryNeededWarning hasPadding />
                 {deviceNetworks.map(symbol => (

--- a/suite-native/atoms/src/CompoundRoundedIcon.tsx
+++ b/suite-native/atoms/src/CompoundRoundedIcon.tsx
@@ -1,0 +1,88 @@
+import { G } from '@mobily/ts-belt';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { CryptoIcon, Icon, IconName, IconSize, icons } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { Color } from '@trezor/theme';
+
+import { Box, BoxProps } from './Box';
+
+export type CompoundRoundedIconProps = {
+    symbol?: NetworkSymbol;
+    contractAddress?: TokenAddress;
+    compoundIcons: {
+        name?: IconName;
+        color?: Color;
+        size?: IconSize;
+    }[];
+    containerSize?: number;
+    backgroundColor?: Color;
+} & BoxProps;
+
+const DEFAULT_CONTAINER_SIZE = 48;
+
+const iconContainerStyle = prepareNativeStyle<{
+    backgroundColor?: Color;
+    containerSizeWidth?: number;
+    containerSizeHeight?: number;
+}>((utils, { backgroundColor, containerSizeWidth, containerSizeHeight }) => ({
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: containerSizeWidth ?? DEFAULT_CONTAINER_SIZE,
+    height: containerSizeHeight ?? DEFAULT_CONTAINER_SIZE,
+    backgroundColor: utils.colors.backgroundSurfaceElevation2,
+    borderRadius: utils.borders.radii.round,
+    flexDirection: 'row',
+    gap: utils.spacings.sp4,
+
+    extend: {
+        condition: G.isNotNullable(backgroundColor),
+        style: {
+            backgroundColor: utils.colors[backgroundColor as Color],
+        },
+    },
+}));
+
+export const CompoundRoundedIcon = ({
+    symbol,
+    compoundIcons,
+    contractAddress,
+    backgroundColor,
+    containerSize,
+    style,
+    ...boxProps
+}: CompoundRoundedIconProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const iconsCount = compoundIcons?.length ?? 0;
+    const containerSizeWidth =
+        containerSize && iconsCount > 0 ? iconsCount * containerSize : undefined;
+
+    return (
+        <Box
+            style={[
+                applyStyle(iconContainerStyle, {
+                    backgroundColor,
+                    containerSizeWidth,
+                    containerSizeHeight: containerSize,
+                }),
+                style,
+            ]}
+            {...boxProps}
+        >
+            {compoundIcons.map(({ name, color, size }) =>
+                name && name in icons ? (
+                    <Icon
+                        name={name as IconName}
+                        color={color}
+                        size={size}
+                        key={`${name}-${color ?? 'default'}-${size ?? 'default'}`}
+                    />
+                ) : (
+                    symbol && <CryptoIcon symbol={symbol} contractAddress={contractAddress} />
+                ),
+            )}
+        </Box>
+    );
+};

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -54,6 +54,7 @@ export * from './TitleHeader/PictogramTitleHeader';
 export * from './TitleHeader/TitleHeader';
 export * from './TitleHeader/CenteredTitleHeader';
 export * from './RoundedIcon';
+export * from './CompoundRoundedIcon';
 export * from './TrezorSuiteHeader';
 export * from './Skeleton/BoxSkeleton';
 export * from './Skeleton/ListItemSkeleton';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -168,6 +168,7 @@ export const messages = {
         numberOfTokens: '+{numberOfTokens, plural, one{1 Token} other{# Tokens}}',
         tokens: 'Tokens',
         staking: 'Staking',
+        rewardsReduced: 'Rewards reduced',
         stakingDisabled: 'Staking is not available in this context.',
     },
     assets: {
@@ -2244,6 +2245,7 @@ export const messages = {
             providerReducingRewards:
                 'Your current provider is reducing ADA rewards. Update your provider on desktop and earn {apy}% APY.',
             updateToNewProvider: `Update to our new provider, Everstake, and earn ~{apy}% APY. Your ADA with our previous provider is safe, and your rewards stay intact, though rates aren’t guaranteed.`,
+            rewardsReduced: 'Cardano staking rewards reduced',
         },
         notAvailable: 'Not available',
         notAvailableShort: 'N/A',

--- a/suite-native/module-staking-management/src/components/FiveBinariesHomeBanner.tsx
+++ b/suite-native/module-staking-management/src/components/FiveBinariesHomeBanner.tsx
@@ -1,0 +1,46 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { AccountsRootState, DeviceRootState } from '@suite-common/wallet-core';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsParamList,
+    AppTabsRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    TabToStackCompositeNavigationProp,
+} from '@suite-native/navigation';
+import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking/src/cardanoStakingSelectors';
+
+type NavigationProp = TabToStackCompositeNavigationProp<
+    AppTabsParamList,
+    AppTabsRoutes.HomeStack,
+    RootStackParamList
+>;
+
+export const FiveBinariesHomeBanner = () => {
+    const navigation = useNavigation<NavigationProp>();
+
+    const account = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectFirstCardanoAccountStakedWithFiveBinaries(state),
+    );
+
+    if (!account) return null;
+
+    const handleButtonPress = () => {
+        navigation.navigate(RootStackRoutes.StakingDetail, {
+            accountKey: account.key,
+        });
+    };
+
+    return (
+        <InlineAlertBox
+            variant="warning"
+            title={<Translation id="staking.infoBanner.rewardsReduced" />}
+            buttonLabel={<Translation id="generic.buttons.learnMore" />}
+            onButtonPress={handleButtonPress}
+        />
+    );
+};

--- a/suite-native/module-staking-management/src/index.ts
+++ b/suite-native/module-staking-management/src/index.ts
@@ -1,1 +1,2 @@
 export { StakingDetailScreen } from './screens/StakingDetailScreen';
+export { FiveBinariesHomeBanner } from './components/FiveBinariesHomeBanner';

--- a/suite-native/staking/src/cardanoStakingSelectors.ts
+++ b/suite-native/staking/src/cardanoStakingSelectors.ts
@@ -85,3 +85,9 @@ export const selectIsCardanoStakedOutsideEverstake = (
 
     return isCardanoStakedOutsideEverstake(account, cardanoStakingPool);
 };
+export const selectFirstCardanoAccountStakedWithFiveBinaries = createMemoizedSelector(
+    [selectDeviceAccounts],
+    accounts =>
+        accounts.find(account => account.visible && isCardanoStakedWithFiveBinaries(account)) ??
+        null,
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improves visibility of the Cardano staking migration on mobile by adding a warning banner above the assets list and an exclamation mark next to affected ADA accounts. Shown only to users staking ADA with Five Binaries, with a CTA leading to the staking details. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23841

## Screenshots:
<img width="49%" height="1062" alt="image" src="https://github.com/user-attachments/assets/793b521d-58db-455d-9681-7128524ddcb6" />
<img width="49%" height="946" alt="image" src="https://github.com/user-attachments/assets/a3d3b8a2-4993-4d7e-a3c4-d4ac84bc5288" />
<img width="49%" height="612" alt="image" src="https://github.com/user-attachments/assets/907b4acd-ba50-44bb-9e65-fcae807d9b64" />
<img width="49%" height="690" alt="image" src="https://github.com/user-attachments/assets/f4532fe2-3930-4688-a3cb-bb003233cb91" />




