### PR TITLE
Feat/solana outside staking info message

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -436,7 +436,12 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     // Not necessary for basic and tokens details
     if (!['basic', 'tokens'].includes(details)) {
         const solEpoch = await getEpoch();
-        const solStakingAccounts = await getSolanaStakingData(api?.rpc, publicKey, solEpoch);
+        const solStakingAccounts = await getSolanaStakingData(
+            api?.rpc,
+            publicKey,
+            solEpoch,
+            'only',
+        );
 
         misc = {
             solStakingAccounts,

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -83,9 +83,10 @@ export const getDelegations = async (
 };
 
 export const getSolanaStakingData = async (
-    rpc: RpcMainnet<SolanaRpcApiMainnet>,
+    rpc: RpcMainnet<SolanaRpcApiMainnet> | Rpc<SolanaRpcApiMainnet>,
     descriptor: string,
     epoch: number,
+    everstakeAccountsFilter: 'all' | 'only' | 'exclude' = 'all',
 ): Promise<SolanaStakingAccount[]> => {
     const stakingAccounts = await getDelegations(rpc, descriptor);
 
@@ -103,12 +104,15 @@ export const getSolanaStakingData = async (
                 const { fields } = state;
 
                 const voterPubkey = fields[1]?.delegation?.voterPubkey;
-                if (!EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey)) return; // filter out non-everstake accounts
+                const isEverStake = EVERSTAKE_VOTER_PUBKEYS.includes(voterPubkey);
+                if (everstakeAccountsFilter === 'only' && !isEverStake) return; // filter out non-everstake accounts
+                if (everstakeAccountsFilter === 'exclude' && isEverStake) return; // filter out everstake accounts
 
                 return {
                     rentExemptReserve: fields[0]?.rentExemptReserve.toString(),
                     stake: fields[1]?.delegation?.stake.toString(),
                     status: stakeState,
+                    isEverStake,
                 };
             }
         })

--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -2498,5 +2498,7 @@
   "TR_YOU_WERE_DISCONNECTED_DOT": "You're offline. Some features will be available once you're connected again.",
   "TR_ZERO_PHISHING_BANNER": "Proceed with caution. This may be a fraudulent transaction. <a>Learn more</a>",
   "TR_ZERO_PHISHING_TOOLTIP": "Address poisoning alert! This transaction looks suspicious. <a>Learn more</a>",
-  "ZERO_BALANCE_TOKENS": "Zero-balance tokens"
+  "ZERO_BALANCE_TOKENS": "Zero-balance tokens",
+  "TR_OUTSIDE_STAKING_CARD_TITLE": "You're staking outside of Trezor Suite",
+  "TR_OUTSIDE_STAKING_CARD_TEXT": "{amount} {displaySymbol} (= {fiat}) is currently staked elsewhere."
 }

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -16,14 +16,15 @@ import { useSolanaRewards } from 'src/hooks/wallet/useSolanaRewards';
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
 import { RewardsList } from './Rewards/RewardsList';
 import { StakingRewardsWarning } from './StakingRewardsWarning';
+import { useOutsideStakingData } from './hooks/useOutsideStakingData';
 import { useRewardsNotAvailableYet } from './hooks/useRewardsNotAvailableYet';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
 import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { DiscoveryWarning } from '../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard';
+import { OutsideStakingCard } from '../StakingDashboard/components/OutsideStakingCard';
 import { PayoutCardFrequencyRewards } from '../StakingDashboard/components/PayoutCardFrequencyRewards';
 import { StakingCard } from '../StakingDashboard/components/StakingCard';
-
 interface SolStakingDashboardProps {
     selectedAccount: SelectedAccountLoaded;
 }
@@ -45,6 +46,10 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
         account,
         rewards.selectedAccountRewards?.[0],
     );
+
+    const { hasStakingAccounts, totalStaked } = useOutsideStakingData({
+        account,
+    });
 
     return (
         <StakingDashboard
@@ -81,10 +86,24 @@ export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProp
                                     />
                                 </Column>
                             </DashboardSection>
+                            {hasStakingAccounts && (
+                                <OutsideStakingCard
+                                    symbol={account.symbol}
+                                    totalStaked={totalStaked}
+                                />
+                            )}
                             <RewardsList account={account} rewards={rewards} />
                         </>
                     ) : (
-                        <EmptyStakingCard />
+                        <>
+                            {hasStakingAccounts && (
+                                <OutsideStakingCard
+                                    symbol={account.symbol}
+                                    totalStaked={totalStaked}
+                                />
+                            )}
+                            <EmptyStakingCard />
+                        </>
                     )}
                 </Column>
             }

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/hooks/useOutsideStakingData.ts
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/hooks/useOutsideStakingData.ts
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { selectSolanaWalletSdkNetwork } from '@suite-common/staking-solana';
+import { selectBlockchainState } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import { getSolanaStakingData } from '@trezor/blockchain-link/src/workers/solana/utils/stakingAccounts';
+import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
+
+import { useSelector } from 'src/hooks/suite';
+
+type useOutsideStakingDataParams = {
+    account: Account;
+};
+
+export const useOutsideStakingData = ({ account }: useOutsideStakingDataParams) => {
+    const blockchain = useSelector(selectBlockchainState);
+    const selectedBlockchain = blockchain[account.symbol];
+
+    const [stakingAccounts, setStakingAccounts] = useState<SolanaStakingAccount[]>();
+
+    useEffect(() => {
+        const url = selectedBlockchain?.url;
+        if (account.networkType !== 'solana' || !url) return;
+
+        let cancelled = false;
+
+        (async () => {
+            try {
+                const { connection } = selectSolanaWalletSdkNetwork(account.symbol, url);
+
+                const { epoch } = await connection.getEpochInfo().send();
+                if (cancelled) return;
+
+                const solEpoch = Number(epoch);
+                const accounts = await getSolanaStakingData(
+                    connection,
+                    account.descriptor,
+                    solEpoch,
+                    'exclude',
+                );
+
+                setStakingAccounts(accounts);
+            } catch {
+                if (!cancelled) setStakingAccounts(undefined);
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [account.descriptor, account.networkType, account.symbol, selectedBlockchain?.url]);
+
+    const totalStaked = useMemo(() => {
+        const totalLamports = (stakingAccounts ?? []).reduce(
+            (sum, { stake }) => sum + BigInt(stake ?? '0'),
+            0n,
+        );
+
+        return totalLamports.toString();
+    }, [stakingAccounts]);
+
+    const hasStakingAccounts = (stakingAccounts?.length ?? 0) > 0;
+
+    return { hasStakingAccounts, totalStaked } as const;
+};

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/OutsideStakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/OutsideStakingCard.tsx
@@ -1,0 +1,51 @@
+import { Translation } from '@suite/intl';
+import { NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { Card, Column, H3, IconCircle, Paragraph, Row } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { DashboardSection } from 'src/components/dashboard';
+import { BaseCurrencyValue } from 'src/components/suite';
+
+type OutsideStakingCardProps = {
+    symbol: NetworkSymbol;
+    totalStaked: string;
+};
+
+export const OutsideStakingCard = ({ symbol, totalStaked }: OutsideStakingCardProps) => {
+    const displaySymbol = getDisplaySymbol(symbol);
+    const totalStakedInUnits = subunitsToUnits({
+        value: asAmountSubunit(new BigNumber(totalStaked || '0')),
+        symbol,
+    }).toString();
+
+    return (
+        <DashboardSection data-testid="@wallet/staking/outside-staking-card">
+            <Card paddingType="large">
+                <Row alignItems="start" gap={16}>
+                    <IconCircle name="puzzlePiece" variant="primary" size={44} />
+                    <Column gap={4}>
+                        <H3>
+                            <Translation id="TR_OUTSIDE_STAKING_CARD_TITLE" />
+                        </H3>
+                        <Paragraph variant="tertiary" maxWidth={700}>
+                            <Translation
+                                id="TR_OUTSIDE_STAKING_CARD_TEXT"
+                                values={{
+                                    amount: totalStakedInUnits,
+                                    displaySymbol,
+                                    fiat: (
+                                        <BaseCurrencyValue
+                                            amount={totalStakedInUnits}
+                                            symbol={symbol}
+                                        />
+                                    ),
+                                }}
+                            />
+                        </Paragraph>
+                    </Column>
+                </Row>
+            </Card>
+        </DashboardSection>
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10778,4 +10778,12 @@ export const messages = defineMessages({
         id: 'TR_NON_TRADABLE_TOKENS',
         defaultMessage: 'Non-tradable tokens',
     },
+    TR_OUTSIDE_STAKING_CARD_TITLE: {
+        id: 'TR_OUTSIDE_STAKING_CARD_TITLE',
+        defaultMessage: "You're staking outside of Trezor Suite",
+    },
+    TR_OUTSIDE_STAKING_CARD_TEXT: {
+        id: 'TR_OUTSIDE_STAKING_CARD_TEXT',
+        defaultMessage: '{amount} {displaySymbol} (= {fiat}) is currently staked elsewhere.',
+    },
 } as const);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implemented support for detecting and displaying Solana staking accounts created outside of Trezor Suite (non-Everstake).

## Notes for QA

You should test 4 cases:

Stake outside of Trezor
Stake via Trezor
Mix - outside Trezor and via it
Without any stake

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/19075

## Screenshots:
<img width="1428" height="906" alt="Screenshot 2026-01-30 at 09 36 51" src="https://github.com/user-attachments/assets/ccf6256f-22f4-4e2d-9838-9a95a4c683e7" />
<img width="1425" height="914" alt="Screenshot 2026-01-30 at 09 41 26" src="https://github.com/user-attachments/assets/ac56a15d-2ce0-4abd-be68-64f3a861789e" />
<img width="1429" height="910" alt="Screenshot 2026-01-30 at 09 45 17" src="https://github.com/user-attachments/assets/4e33de6e-b152-48c9-ab28-59a185db575d" />
<img width="1436" height="915" alt="Screenshot 2026-01-30 at 09 48 38" src="https://github.com/user-attachments/assets/ee7adbea-89ef-4087-a43b-c045afe69d26" />
